### PR TITLE
Docs: consumer guides for ModdableTimberborn

### DIFF
--- a/Docs/ModdableTimberborn/Areas.MD
+++ b/Docs/ModdableTimberborn/Areas.MD
@@ -1,0 +1,171 @@
+# Areas
+
+The Areas subsystem answers the question: _which characters are inside this zone right now?_ Timberborn has no built-in spatial query for runtime entity position, so this subsystem fills that gap. You define one or more rectangular volumes (`BoundsInt`), register them with a service, and get back a live handle that maintains an up-to-date set of matching characters and fires enter/exit events as they cross the boundary.
+
+Performance is kept in check by a **segment grid**: the map is partitioned into 26×26-tile squares on load. Each registered area is mapped to the segments it overlaps; on every tile-boundary crossing only the handles whose segments match the character's old or new position are evaluated — avoiding a full O(handles × characters) scan per tick.
+
+## Enabling the subsystem
+
+Call `UseAreaApis()` from your `IModStarter` before the game loads:
+
+```cs
+public class MStarter : IModStarter
+{
+    void IModStarter.StartMod(IModEnvironment modEnvironment)
+    {
+        ModdableTimberbornRegistry.Instance
+            .UseAreaApis();
+    }
+}
+```
+
+`UseAreaApis()` is idempotent. It also calls `UseEntityTracker()` internally, so you do not need to enable the Entity Tracker separately when using Areas.
+
+## Core types
+
+| Type | Role |
+|---|---|
+| [`AreaCondition`](../../ModdableTimberborn/Areas/AreaCondition.cs) | Enum: `Intersects` or `Contains`. Used by `AreaExtensions.Evaluate`. |
+| [`CharacterAreaTrackerRegistration`](../../ModdableTimberborn/Areas/AreaTrackerRegistration.cs) | Data bag describing the zone(s) and character filter for a single tracking request. |
+| [`CharacterAreaTrackerHandle`](../../ModdableTimberborn/Areas/CharacterAreaTrackerHandle.cs) | Live handle returned by the service. Exposes the `Entities` set and enter/exit events. |
+| [`CharacterAreaTrackerService`](../../ModdableTimberborn/Areas/CharacterAreaTrackerService.cs) | Singleton service. Register and unregister handles here. |
+| [`AreaSegmentService`](../../ModdableTimberborn/Areas/AreaSegmentService.cs) | Singleton spatial index. Used internally; rarely needed directly. |
+| [`SerializableBoundsInts`](../../ModdableTimberborn/Areas/SerializableBounds.cs) | JSON-safe wrapper for `BoundsInt`, with implicit casts. Useful when storing zone definitions in spec files. |
+
+### `CharacterAreaTrackerRegistration`
+
+```cs
+public class CharacterAreaTrackerRegistration : AreaTrackerRegistration
+{
+    public BoundsInt[] Areas { get; set; } = [];
+    public CharacterType CharacterTypes { get; set; } = CharacterType.All;
+}
+```
+
+- **`Areas`** — One or more rectangular volumes. At least one is required; the handle throws `ArgumentException` otherwise.
+- **`CharacterTypes`** — Flags controlling which character types are tracked. Defaults to `CharacterType.All`. `CharacterType.Unknown` is not valid and will throw.
+
+  Valid `CharacterType` flag values:
+
+  | Value | Members |
+  |---|---|
+  | `Bot` | Bots only |
+  | `AdultBeaver` | Adult beavers only |
+  | `ChildBeaver` | Child beavers only |
+  | `Beavers` | `AdultBeaver \| ChildBeaver` |
+  | `Workers` | `AdultBeaver \| Bot` |
+  | `All` | `Beavers \| Bot` (every tracked type) |
+
+> **Immutability:** `Areas` and `Segments` are computed once in the handle constructor and are read-only. To change a zone, call `UnregisterArea` on the existing handle and `RegisterArea` a new registration.
+
+### `CharacterAreaTrackerHandle`
+
+Returned by `CharacterAreaTrackerService.RegisterArea`. Inherits from `AreaTrackerHandle<CharacterPositionTracker, CharacterAreaTrackerRegistration>`.
+
+```cs
+// Live set of characters currently inside the zone(s):
+IReadOnlyCollection<CharacterPositionTracker> Entities { get; }
+
+int Count { get; }
+bool HasAny { get; }
+
+// Fired when a character enters any of the areas:
+event EventHandler<CharacterPositionTracker> OnEntityEntered;
+
+// Fired when a character leaves all of the areas:
+event EventHandler<CharacterPositionTracker> OnEntityExited;
+```
+
+## Worked example
+
+This example tracks all beavers inside a single building footprint and logs each arrival and departure.
+
+```cs
+public class ZoneWatcher : ILoadableSingleton, IUnloadableSingleton
+{
+    readonly CharacterAreaTrackerService _areaService;
+    CharacterAreaTrackerHandle? _handle;
+
+    public ZoneWatcher(CharacterAreaTrackerService areaService)
+    {
+        _areaService = areaService;
+    }
+
+    public void Load()
+    {
+        // Define the zone — for example, a 4×4 footprint at tile (10, 5, 0):
+        var zone = new BoundsInt(new Vector3Int(10, 5, 0), new Vector3Int(4, 4, 1));
+
+        var registration = new CharacterAreaTrackerRegistration
+        {
+            Areas          = [zone],
+            CharacterTypes = CharacterType.Beavers,  // beavers only (AdultBeaver | ChildBeaver)
+        };
+
+        _handle = _areaService.RegisterArea(registration);
+        _handle.OnEntityEntered += OnEntered;
+        _handle.OnEntityExited  += OnExited;
+    }
+
+    public void Unload()
+    {
+        if (_handle is null) { return; }
+
+        _handle.OnEntityEntered -= OnEntered;
+        _handle.OnEntityExited  -= OnExited;
+        _areaService.UnregisterArea(_handle);
+        _handle = null;
+    }
+
+    void OnEntered(object sender, CharacterPositionTracker tracker)
+        => Plugin.Log.LogInfo($"{tracker.Character.name} entered the zone.");
+
+    void OnExited(object sender, CharacterPositionTracker tracker)
+        => Plugin.Log.LogInfo($"{tracker.Character.name} left the zone.");
+}
+```
+
+### Polling instead of events
+
+If you only need a snapshot rather than per-crossing callbacks, skip the event subscriptions and read `_handle.Entities` (or `_handle.Count` / `_handle.HasAny`) directly:
+
+```cs
+int beaversPresent = _handle.Count;
+
+foreach (var tracker in _handle.Entities)
+{
+    // tracker.Character, tracker.Cell, tracker.Position, etc.
+}
+```
+
+### Multiple zones
+
+Pass more than one `BoundsInt` in `Areas` to track a union of rectangles with a single handle. A character is considered inside if it is in **any** of the specified areas:
+
+```cs
+var registration = new CharacterAreaTrackerRegistration
+{
+    Areas = [zoneA, zoneB, zoneC],
+    CharacterTypes = CharacterType.All,
+};
+```
+
+### Serializing zone definitions
+
+Use [`SerializableBoundsInts`](../../ModdableTimberborn/Areas/SerializableBounds.cs) to store `BoundsInt` values in JSON-backed specs. The struct has implicit casts in both directions:
+
+```cs
+SerializableBoundsInts stored = myBoundsInt;   // implicit cast to serializable form
+BoundsInt restored = stored;                   // implicit cast back
+```
+
+## How it works at runtime
+
+1. `UseAreaApis()` attaches a [`CharacterPositionTracker`](../../ModdableTimberborn/Areas/CharacterPositionTracker.cs) `TickableComponent` decorator to every `Character` entity. Each tick it compares `transform.position` to the previous frame, updates `Cell` (floor-to-int) and `Segment`, and fires `OnCellChanged` when a tile boundary is crossed.
+2. [`CharacterAreaTrackerService`](../../ModdableTimberborn/Areas/CharacterAreaTrackerService.cs) subscribes to `OnCellChanged` lazily — only for character types that have at least one registered handle — and unsubscribes when the last handle for a type is removed.
+3. On each cell-change event, the service uses the character's old and new segment indices to look up only the handles that overlap those segments, then evaluates `BoundsInt.Contains(cell)` for each candidate.
+4. The handle maintains its `Entities` set through a `DeferredHashSet` (allowing mutation during event callbacks) and fires `OnEntityEntered` / `OnEntityExited` when membership changes.
+
+## Block-object area tracking — not yet available
+
+[`BlockObjectAreaTrackerRegistration`](../../ModdableTimberborn/Areas/AreaTrackerRegistration.cs) and [`BlockObjectBound`](../../ModdableTimberborn/Areas/BlockObjectBound.cs) are defined and `BlockObjectBound` is attached as a decorator on every `BlockObject` at load time, but there is no `BlockObjectAreaTrackerHandle` or corresponding service yet. The block-object tracking path is **scaffolded but incomplete** and cannot be used in the current release. Character area tracking is the only fully supported path.

--- a/Docs/ModdableTimberborn/BonusSystem.MD
+++ b/Docs/ModdableTimberborn/BonusSystem.MD
@@ -1,0 +1,178 @@
+# Bonus System
+
+The Bonus System lets you attach, replace, and remove named groups of bonus multipliers on any character entity — and optionally persist those groups across saves. It sits on top of Timberborn's native `BonusManager`/`BonusSpec` API and adds a keyed dictionary layer that prevents the common leak problem of adding raw bonuses without tracking what was already applied.
+
+**Relevant source:** [`../../ModdableTimberborn/BonusSystem/`](../../ModdableTimberborn/BonusSystem/)
+
+## Enabling the subsystem
+
+Call one of the opt-in methods on `ModdableTimberbornRegistry.Instance` from your `IModStarter`:
+
+```cs
+ModdableTimberbornRegistry.Instance
+    .UseBonusTracker()           // transient — bonuses are not saved
+    .UsePersistentBonusTracker() // persistent — bonuses survive save/load
+```
+
+`UseBonusTracker(bool persistent)` is also available if the choice is determined at runtime. Both methods are chainable and safe to call multiple times.
+
+Internally, either call registers `BonusSystemConfig`, which decorates every `BonusManager` entity with the appropriate component at game-scene binding time:
+
+- `UseBonusTracker()` → adds `BonusTrackerComponent` to each entity that has a `BonusManager`
+- `UsePersistentBonusTracker()` → adds `PersistentBonusTrackerComponent` instead
+
+Only one variant should be active per game context. If both flags are set, `BonusSystemConfig.Configure` adds **both** decorators independently, so every `BonusManager` entity receives both a `BonusTrackerComponent` and a `PersistentBonusTrackerComponent` — pick exactly one.
+
+## Key types
+
+| Type | Purpose |
+|---|---|
+| [`BonusTrackerItem`](../../ModdableTimberborn/BonusSystem/BonusTrackerItem.cs) | Immutable struct pairing a string `Id` with a list of `BonusSpec` values |
+| [`BonusTracker`](../../ModdableTimberborn/BonusSystem/BonusTracker.cs) | Core logic; owns the keyed dictionary and proxies `BonusManager` |
+| [`IBonusTrackerComponent`](../../ModdableTimberborn/BonusSystem/IBonusTrackerComponent.cs) | Common interface for both component variants; extension methods target this |
+| [`BonusTrackerComponent`](../../ModdableTimberborn/BonusSystem/BonusTrackerComponent.cs) | Transient decorator component (no persistence) |
+| [`PersistentBonusTrackerComponent`](../../ModdableTimberborn/BonusSystem/PersistentBonusTrackerComponent.cs) | Persistent variant; implements `IPersistentEntity` |
+| [`BonusSystemHelpers`](../../ModdableTimberborn/BonusSystem/BonusSystemHelpers.cs) | String constants for the six standard bonus IDs |
+| [`BonusSystemExtensions`](../../ModdableTimberborn/BonusSystem/BonusSystemExtensions.cs) | Fluent `AddOrUpdate` / `Remove` / `CurrentBonuses` on any `IBonusTrackerComponent` |
+
+The `BonusType` enum ([`../../ModdableTimberborn/Helpers/CommonEnums.cs`](../../ModdableTimberborn/Helpers/CommonEnums.cs)) mirrors the same six bonuses as typed members: `CarryingCapacity`, `CuttingSuccessChance`, `GrowthSpeed`, `LifeExpectancy`, `MovementSpeed`, `WorkingSpeed`.
+
+## Constructing a BonusTrackerItem
+
+A `BonusTrackerItem` groups one or more bonuses under a single string key. Several constructors are available:
+
+```cs
+// Multiple bonuses — using BonusType enum (extension method .ToBonusSpec)
+// or using string constants from BonusSystemHelpers
+var item = new BonusTrackerItem("MyBuff", [
+    BonusType.MovementSpeed.ToBonusSpec(0.5f),            // +50 % movement speed
+    new(BonusSystemHelpers.WorkingSpeedId, 0.25f),        // +25 % working speed
+]);
+
+// Single bonus from a BonusType enum value
+var item = new BonusTrackerItem("MyBuff", BonusType.MovementSpeed, 0.5f);
+
+// Single bonus from a raw string ID
+var item = new BonusTrackerItem("MyBuff", BonusSystemHelpers.WorkingSpeedId, 0.25f);
+```
+
+The `MultiplierDelta` values are additive modifiers on top of the base multiplier — `0.5f` means +50 %.
+
+Declare static items at class level so they are only constructed once:
+
+```cs
+static readonly BonusTrackerItem MyBuffBonuses = new("MyBuff", [
+    BonusType.MovementSpeed.ToBonusSpec(0.5f),
+    new(BonusSystemHelpers.WorkingSpeedId, 0.25f),
+]);
+```
+
+## Obtaining the tracker component
+
+Use the extension methods from [`../../ModdableTimberborn/Helpers/CharacterExtensions.cs`](../../ModdableTimberborn/Helpers/CharacterExtensions.cs):
+
+```cs
+// Transient variant
+BonusTrackerComponent tracker = worker.GetBonusTracker();
+
+// Persistent variant
+PersistentBonusTrackerComponent tracker = worker.GetPersistentBonusTracker();
+```
+
+Both return `null` if the corresponding subsystem has not been enabled or if the entity has no `BonusManager`. Both types implement `IBonusTrackerComponent`, so `BonusSystemExtensions` methods work on either.
+
+> **Note:** The helpers are generic (`where T : BaseComponent`) and `BonusSystemConfig` decorates any entity that has a `BonusManager` component — not only characters. You can call `GetBonusTracker()` / `GetPersistentBonusTracker()` on any `BaseComponent` that belongs to such an entity.
+
+## Applying and removing bonuses
+
+Call `AddOrUpdate` to apply a bonus group, and `Remove` to take it away. If a group with the same `Id` already exists, `AddOrUpdate` atomically removes the old bonuses and applies the new ones — there is no double-application.
+
+```cs
+// Apply (or replace) the bonus group
+tracker.AddOrUpdate(MyBuffBonuses);
+
+// Remove it by ID
+tracker.Remove(MyBuffBonuses.Id);
+```
+
+`AddOrUpdate` and `Remove` fire the `BonusTracker.OnBonusChanged` event with a `BonusTrackerChangeEventArgs` that carries the old and new `BonusTrackerItem` values, useful for UI reactions.
+
+To check whether a specific bonus group is currently applied — and retrieve it — use `BonusTracker.TryGetBonus`:
+
+```cs
+if (tracker.BonusTracker.TryGetBonus("MyBuff", out BonusTrackerItem? item))
+{
+    // item.Bonuses contains the active BonusSpec list
+}
+```
+
+This is more targeted than iterating `CurrentBonuses` when you only care about one key.
+
+`BonusTracker` also exposes `AddOrUpdateOrRemove(BonusTrackerItem)` directly. It calls `Remove` automatically when every `MultiplierDelta` in the item is zero, and `AddOrUpdate` otherwise — convenient when the bonus magnitude is computed at runtime and may drop to zero.
+
+## Worked example — workplace buff
+
+The demo's [`DemoWorkplaceBuffComponent`](../../ModdableTimberbornDemo/Features/WorkplaceBuff/DemoWorkplaceBuffComponent.cs) applies bonuses to every worker assigned to a workplace. It extends `TogglableWorkplaceBonusComponent`, which handles the `WorkerAssigned`/`WorkerUnassigned` bookkeeping automatically:
+
+```cs
+using ModdableTimberborn.BonusSystem;
+
+public class DemoWorkplaceBuffComponent : TogglableWorkplaceBonusComponent, IEntityEffectDescriber
+{
+    static readonly BonusTrackerItem DemoBonuses = new("DemoWorkplaceBuff", [
+        BonusType.MovementSpeed.ToBonusSpec(1f),           // Either use BonusType enum
+        new(BonusSystemHelpers.WorkingSpeedId, 1f),        // Or constant from BonusSystemHelpers
+    ]);
+
+    public int Order { get; }
+    protected override BonusTrackerItem Bonuses { get; } = DemoBonuses;
+
+    public EntityEffectDescription? Describe(ILoc t, IDayNightCycle dayNightCycle)
+        => Active
+            ? new("Demo Workplace Buff",
+                  t.T("LV.DemoMT.WorkplaceBuffDesc",
+                      DemoBonuses.Bonuses[0].MultiplierDelta,
+                      DemoBonuses.Bonuses[1].MultiplierDelta))
+            : null;
+}
+```
+
+Register the component as a decorator on `Workplace` from your configurator:
+
+```cs
+public class WorkplaceBuffConfig : IModdableTimberbornRegistryConfig
+{
+    public void Configure(Configurator configurator, ConfigurationContext context)
+    {
+        if (!context.IsGameContext()) { return; }
+
+        configurator
+            .BindTemplateModule(h => h
+                .AddDecorator<Workplace, DemoWorkplaceBuffComponent>()
+            );
+    }
+}
+```
+
+`TogglableWorkplaceBonusComponent` (source: [`../../ModdableTimberborn/WorkSystem/`](../../ModdableTimberborn/WorkSystem/)) requires `UseBonusTracker()` (non-persistent) to be enabled. When `Active` is true the component calls `worker.GetBonusTracker().AddOrUpdate(Bonuses)` on assignment and `.Remove(Bonuses.Id)` on unassignment.
+
+## Persistence behavior
+
+When `UsePersistentBonusTracker()` is enabled, `PersistentBonusTrackerComponent` saves the full `CurrentBonuses` dictionary to the entity's save data. On load the saved items are held in a staging list and replayed in `Start` (after `BonusManager` is fully initialized). If `CurrentBonuses` is empty at save time nothing is written.
+
+The non-persistent `BonusTrackerComponent` applies no save/load logic — any bonuses applied at runtime are lost when the save is loaded and must be reapplied by your code.
+
+## Standard bonus IDs
+
+`BonusSystemHelpers` provides string constants, and `BonusType` provides the equivalent enum values, for the six built-in bonuses:
+
+| Constant | Enum value | Effect |
+|---|---|---|
+| `BonusSystemHelpers.CarryingCapacityId` | `BonusType.CarryingCapacity` | Carry capacity multiplier |
+| `BonusSystemHelpers.CuttingSuccessChanceId` | `BonusType.CuttingSuccessChance` | Tree-cutting success chance |
+| `BonusSystemHelpers.GrowthSpeedId` | `BonusType.GrowthSpeed` | Growth speed multiplier |
+| `BonusSystemHelpers.LifeExpectancyId` | `BonusType.LifeExpectancy` | Life expectancy multiplier |
+| `BonusSystemHelpers.MovementSpeedId` | `BonusType.MovementSpeed` | Movement speed multiplier |
+| `BonusSystemHelpers.WorkingSpeedId` | `BonusType.WorkingSpeed` | Working speed multiplier |
+
+Any `BonusSpec` ID accepted by Timberborn's `BonusManager` can be used — these constants cover the most common cases.

--- a/Docs/ModdableTimberborn/BonusSystem.MD
+++ b/Docs/ModdableTimberborn/BonusSystem.MD
@@ -9,9 +9,12 @@ The Bonus System lets you attach, replace, and remove named groups of bonus mult
 Call one of the opt-in methods on `ModdableTimberbornRegistry.Instance` from your `IModStarter`:
 
 ```cs
+// Pick ONE — enabling both adds both decorators to every BonusManager entity (see below).
 ModdableTimberbornRegistry.Instance
-    .UseBonusTracker()           // transient — bonuses are not saved
-    .UsePersistentBonusTracker() // persistent — bonuses survive save/load
+    .UseBonusTracker();            // transient — bonuses are not saved
+
+// — or — persistent bonuses that survive save/load:
+// ModdableTimberbornRegistry.Instance.UsePersistentBonusTracker();
 ```
 
 `UseBonusTracker(bool persistent)` is also available if the choice is determined at runtime. Both methods are chainable and safe to call multiple times.
@@ -72,11 +75,11 @@ static readonly BonusTrackerItem MyBuffBonuses = new("MyBuff", [
 Use the extension methods from [`../../ModdableTimberborn/Helpers/CharacterExtensions.cs`](../../ModdableTimberborn/Helpers/CharacterExtensions.cs):
 
 ```cs
-// Transient variant
-BonusTrackerComponent tracker = worker.GetBonusTracker();
+// Transient variant — null if UseBonusTracker() wasn't called or the entity has no BonusManager
+BonusTrackerComponent? tracker = worker.GetBonusTracker();
 
 // Persistent variant
-PersistentBonusTrackerComponent tracker = worker.GetPersistentBonusTracker();
+PersistentBonusTrackerComponent? persistentTracker = worker.GetPersistentBonusTracker();
 ```
 
 Both return `null` if the corresponding subsystem has not been enabled or if the entity has no `BonusManager`. Both types implement `IBonusTrackerComponent`, so `BonusSystemExtensions` methods work on either.

--- a/Docs/ModdableTimberborn/BuildingSettings.MD
+++ b/Docs/ModdableTimberborn/BuildingSettings.MD
@@ -1,0 +1,188 @@
+# Building Settings
+
+The Building Settings subsystem gives buildings **persistent, copy/paste-able configuration**. Each handler knows how to snapshot one `IDuplicable` component to JSON and reapply it to another instance of the same type — whether for a single building or when pasting settings across saves with different entity IDs.
+
+ModdableTimberborn ships with handlers for every stock Timberborn `IDuplicable` component. You can also write your own handlers; they are discovered and registered automatically.
+
+## Enabling the subsystem
+
+Call `UseBuildingSettings()` from your `IModStarter`:
+
+```cs
+public class MStarter : IModStarter
+{
+    void IModStarter.StartMod(IModEnvironment modEnvironment)
+    {
+        ModdableTimberbornRegistry.Instance
+            .UseBuildingSettings()
+            // ... other subsystems
+        ;
+    }
+}
+```
+
+This is idempotent and chainable. Internally it adds [`BuildingSettingsConfig`](../../ModdableTimberborn/BuildingSettings/BuildingSettingsConfig.cs), which registers `BuildingSettingsResolver` as a singleton and auto-discovers every concrete `IBuildingSettings` in the assembly.
+
+## Using the resolver
+
+[`BuildingSettingsResolver`](../../ModdableTimberborn/BuildingSettings/BuildingSettingsResolver.cs) is the main entry point for consumers. Inject it wherever you need to snapshot or apply settings:
+
+```cs
+// Snapshot all settings for a building
+BuildingSettingsPair[] pairs = resolver.Get(myBuilding);
+
+// Reapply stored settings to a target building
+foreach (var pair in pairs)
+{
+    string json = pair.Settings.Serialize(pair.Duplicable);
+    pair.Settings.Deserialize(json, pair.Duplicable);
+}
+```
+
+`BuildingSettingsPair` is a `readonly record struct(IDuplicable Duplicable, IBuildingSettings Settings)`. The `Get(BaseComponent)` overload queries all `IDuplicable` components on the building and returns one pair per component that has a registered handler.
+
+An optional `HashSet<IBuildingSettings>` filter can restrict which handlers are applied — useful when a UI only exposes a subset of settings.
+
+### Entity-GUID remapping (cross-save paste)
+
+Some settings store references to other entities (automators, relays, timers). When pasting across saves the GUIDs differ. Before deserializing, check for `IEntityIdBuildingSettings` and pass the `idMappings` dictionary:
+
+```cs
+foreach (var pair in pairs)
+{
+    if (pair.Settings is IEntityIdBuildingSettings entitySettings)
+    {
+        entitySettings.Deserialize(json, pair.Duplicable, idMappings);
+    }
+    else
+    {
+        pair.Settings.Deserialize(json, pair.Duplicable);
+    }
+}
+```
+
+## Writing a custom handler
+
+### 1. Define a model record
+
+The model is a plain record that Newtonsoft.Json serializes. For a simple scalar value, use one of the shared primitives in [`CommonSettingModels.cs`](../../ModdableTimberborn/BuildingSettings/BuiltInSettings/CommonSettingModels.cs) (`BoolSettingModel`, `IntSettingModel`, `FloatSettingModel`, `StringSettingModel`). For anything richer, define your own:
+
+```cs
+public record MyComponentSettingsModel(int Threshold, bool IsEnabled);
+```
+
+Use `[JsonIgnore]` on any computed or cached properties that should not be persisted.
+
+### 2. Extend `BuildingSettingsBase<T, TModel>`
+
+[`BuildingSettingsBase<T, TModel>`](../../ModdableTimberborn/BuildingSettings/BuildingSettingsBase.cs) is the abstract base for most handlers. You must override three members:
+
+| Member | Responsibility |
+|---|---|
+| `GetModel(T duplicable)` | Snapshot the component's current state to a model record. |
+| `ApplyModel(TModel model, T target)` | Push the model's values back onto the target component. Return `true` if the apply succeeded. |
+| `DescribeModel(TModel model)` | Return a short, localized one-line summary of the model for display in the UI. |
+
+`T` must be a `BaseComponent` that also implements `IDuplicable<T>`. The base class resolves the localized `Name` via the key `LV.MT.BldSet.<TypeName>` during game load.
+
+#### Minimal example
+
+Here is a handler for a hypothetical `MyComponent` that exposes a single `int` worker count, modeled on the built-in [`WorkplaceSettings`](../../ModdableTimberborn/BuildingSettings/BuiltInSettings/WorkplaceSettings.cs):
+
+```cs
+public class MyComponentSettings(ILoc t) 
+    : BuildingSettingsBase<MyComponent, IntSettingModel>(t)
+{
+    // Snapshot: read the current state off the component.
+    protected override IntSettingModel GetModel(MyComponent duplicable)
+        => duplicable.CurrentCount;
+
+    // Apply: push the stored value back, with any guards you need.
+    protected override bool ApplyModel(IntSettingModel model, MyComponent target)
+    {
+        target.SetCount(Math.Min(model.Value, target.MaxCount));
+        return true;
+    }
+
+    // Describe: one-line summary shown in the paste-preview UI.
+    public override string DescribeModel(IntSettingModel model)
+        => model.Value.ToString();
+}
+```
+
+You can override `CanDeserialize(T? target)` to add extra guards before the model is applied (the base implementation checks `target != null && target.IsDuplicable`).
+
+#### Controlling apply order
+
+The default `Order` is `1000`. Override `IBuildingSettings.Order` explicitly if your handler must run before others — for example the built-in `PausableBuildingSettings` uses `100` so pause state is set before any other settings are applied:
+
+```cs
+public class MyEarlySettings(ILoc t) : BuildingSettingsBase<MyComponent, BoolSettingModel>(t), IBuildingSettings
+{
+    int IBuildingSettings.Order => 50;
+    // ...
+}
+```
+
+### 3. Handlers that reference other entities
+
+If your model stores a reference to another entity (by `Guid`), inherit [`EntityIdBuildingSettingsBase<T, TModel>`](../../ModdableTimberborn/BuildingSettings/EntityIdBuildingSettingsBase.cs) instead, and let your model record extend `EntityIdModelBase`. The base class handles GUID substitution generically when the caller provides an `idMappings` dictionary.
+
+```cs
+// Model: expose each entity GUID through the EntityIds slot array.
+public record MyLinkedSettingsModel(Guid? LinkedId)
+    : EntityIdModelBase([LinkedId])
+{
+    public Guid? LinkedId
+    {
+        get => EntityIds[0];
+        set => EntityIds[0] = value;
+    }
+}
+
+public class MyLinkedSettings(EntityRegistry entityRegistry, ILoc t)
+    : EntityIdBuildingSettingsBase<MyLinkedComponent, MyLinkedSettingsModel>(t)
+{
+    protected override MyLinkedSettingsModel GetModel(MyLinkedComponent duplicable)
+        => new(duplicable.LinkedEntity?.EntityId);
+
+    protected override bool ApplyModel(MyLinkedSettingsModel model, MyLinkedComponent target)
+    {
+        var entity = entityRegistry.TryGetEntity(model.LinkedId);
+        target.SetLinked(entity);
+        return true;
+    }
+
+    public override string DescribeModel(MyLinkedSettingsModel model)
+        => entityRegistry.DescribeEntity(model.LinkedId, t);
+}
+```
+
+See [`AutomatableSettings`](../../ModdableTimberborn/BuildingSettings/BuiltInSettings/AutomatableSettings.cs) for the canonical real-world example.
+
+### 4. No manual registration needed
+
+`BuildingSettingsConfig` scans the assembly at startup and registers every non-abstract `IBuildingSettings` class it finds as a multibind singleton. Add the class; nothing else is required.
+
+## Built-in handlers
+
+ModdableTimberborn includes handlers for all stock Timberborn `IDuplicable` components — floodgates, manufactories, workplaces, sensors, levers, and more. They live in [`BuiltInSettings/`](../../ModdableTimberborn/BuildingSettings/BuiltInSettings/) and are good reading material for patterns:
+
+- **Simple scalar** — [`WorkplaceSettings`](../../ModdableTimberborn/BuildingSettings/BuiltInSettings/WorkplaceSettings.cs), [`WaterSourceSettings`](../../ModdableTimberborn/BuildingSettings/BuiltInSettings/WaterSourceSettings.cs)
+- **Bool toggle** — [`PausableBuildingSettings`](../../ModdableTimberborn/BuildingSettings/BuiltInSettings/PausableBuildingSettings.cs), [`DemolishableSettings`](../../ModdableTimberborn/BuildingSettings/BuiltInSettings/DemolishableSettings.cs)
+- **Rich model with guards** — [`FloodgateSettings`](../../ModdableTimberborn/BuildingSettings/BuiltInSettings/FloodgateSettings.cs), [`ManufactorySettings`](../../ModdableTimberborn/BuildingSettings/BuiltInSettings/ManufactorySettings.cs)
+- **String-ID lookup with lazy caching** — [`SingleGoodAllowerSettings`](../../ModdableTimberborn/BuildingSettings/BuiltInSettings/SingleGoodAllowerSettings.cs) (uses `CachableStringSettingModel<GoodSpec>`)
+- **Entity-linked** — [`AutomatableSettings`](../../ModdableTimberborn/BuildingSettings/BuiltInSettings/AutomatableSettings.cs), [`RelaySettings`](../../ModdableTimberborn/BuildingSettings/BuiltInSettings/RelaySettings.cs)
+
+## Key types at a glance
+
+| Type | Role |
+|---|---|
+| [`IBuildingSettings`](../../ModdableTimberborn/BuildingSettings/IBuildingSettings.cs) | Core interface: serialize, deserialize, describe, order. |
+| [`BuildingSettingsBase<T, TModel>`](../../ModdableTimberborn/BuildingSettings/BuildingSettingsBase.cs) | Abstract base; override `GetModel`, `ApplyModel`, `DescribeModel`. |
+| [`EntityIdBuildingSettingsBase<T, TModel>`](../../ModdableTimberborn/BuildingSettings/EntityIdBuildingSettingsBase.cs) | Variant for handlers whose model contains entity GUIDs. |
+| [`IEntityIdBuildingSettings`](../../ModdableTimberborn/BuildingSettings/IEntityIdBuildingSettings.cs) | Marker interface; callers use it to decide whether to pass `idMappings`. |
+| [`IEntityIdModel` / `EntityIdModelBase`](../../ModdableTimberborn/BuildingSettings/IEntityIdModel.cs) | Model base that exposes the `Guid?[]` slot array for generic remapping. |
+| [`BuildingSettingsResolver`](../../ModdableTimberborn/BuildingSettings/BuildingSettingsResolver.cs) | Singleton; resolves handlers by type and returns `BuildingSettingsPair[]` for a building. |
+| [`BuildingSettingsPair`](../../ModdableTimberborn/BuildingSettings/BuildingSettingsResolver.cs) | `readonly record struct(IDuplicable, IBuildingSettings)` returned by the resolver. |
+| [`BuildingSettingsConfig`](../../ModdableTimberborn/BuildingSettings/BuildingSettingsConfig.cs) | Registry config; activated by `UseBuildingSettings()`. Auto-discovers all handlers. |

--- a/Docs/ModdableTimberborn/BuildingSettings.MD
+++ b/Docs/ModdableTimberborn/BuildingSettings.MD
@@ -21,7 +21,7 @@ public class MStarter : IModStarter
 }
 ```
 
-This is idempotent and chainable. Internally it adds [`BuildingSettingsConfig`](../../ModdableTimberborn/BuildingSettings/BuildingSettingsConfig.cs), which registers `BuildingSettingsResolver` as a singleton and auto-discovers every concrete `IBuildingSettings` in the assembly.
+This is idempotent and chainable. Internally it adds [`BuildingSettingsConfig`](../../ModdableTimberborn/BuildingSettings/BuildingSettingsConfig.cs), which registers `BuildingSettingsResolver` as a singleton and auto-discovers every concrete `IBuildingSettings` in **ModdableTimberborn's own assembly**. Handlers you define in your own mod must be registered manually — see [Registering a custom handler](#4-registering-a-custom-handler).
 
 ## Using the resolver
 
@@ -160,9 +160,13 @@ public class MyLinkedSettings(EntityRegistry entityRegistry, ILoc t)
 
 See [`AutomatableSettings`](../../ModdableTimberborn/BuildingSettings/BuiltInSettings/AutomatableSettings.cs) for the canonical real-world example.
 
-### 4. No manual registration needed
+### 4. Registering a custom handler
 
-`BuildingSettingsConfig` scans the assembly at startup and registers every non-abstract `IBuildingSettings` class it finds as a multibind singleton. Add the class; nothing else is required.
+`BuildingSettingsConfig` scans **only the ModdableTimberborn assembly** (`typeof(BuildingSettingsConfig).Assembly`) and auto-registers every non-abstract `IBuildingSettings` it finds *there*. A handler defined in **your own** mod assembly is therefore **not** picked up automatically — multibind it yourself in your configurator:
+
+```cs
+configurator.MultiBind(typeof(IBuildingSettings), typeof(MyBuildingSettings)).AsSingleton();
+```
 
 ## Built-in handlers
 
@@ -185,4 +189,4 @@ ModdableTimberborn includes handlers for all stock Timberborn `IDuplicable` comp
 | [`IEntityIdModel` / `EntityIdModelBase`](../../ModdableTimberborn/BuildingSettings/IEntityIdModel.cs) | Model base that exposes the `Guid?[]` slot array for generic remapping. |
 | [`BuildingSettingsResolver`](../../ModdableTimberborn/BuildingSettings/BuildingSettingsResolver.cs) | Singleton; resolves handlers by type and returns `BuildingSettingsPair[]` for a building. |
 | [`BuildingSettingsPair`](../../ModdableTimberborn/BuildingSettings/BuildingSettingsResolver.cs) | `readonly record struct(IDuplicable, IBuildingSettings)` returned by the resolver. |
-| [`BuildingSettingsConfig`](../../ModdableTimberborn/BuildingSettings/BuildingSettingsConfig.cs) | Registry config; activated by `UseBuildingSettings()`. Auto-discovers all handlers. |
+| [`BuildingSettingsConfig`](../../ModdableTimberborn/BuildingSettings/BuildingSettingsConfig.cs) | Registry config; activated by `UseBuildingSettings()`. Auto-discovers handlers in the ModdableTimberborn assembly; register your own with `MultiBind`. |

--- a/Docs/ModdableTimberborn/EffectComponents.MD
+++ b/Docs/ModdableTimberborn/EffectComponents.MD
@@ -1,0 +1,280 @@
+# Effect Components
+
+Effect components are abstract base classes you subclass to apply a togglable effect — often a bonus (see [Bonus System](./BonusSystem.MD)) — to characters based on a specific relationship. All three families follow the same pattern: a component attached to a `GameObject` monitors a set of members (enterers, assigned workers, or any character in water) and applies or removes an effect as membership changes, while respecting an on/off toggle.
+
+The toggle infrastructure is defined in [`Common`](../../ModdableTimberborn/Common/): `ITogglableContainer<TContainer, TMember>` exposes `Toggle(bool)`, convenience `Activate()` / `Deactivate()` helpers, and a `Toggled` event. `BaseTogglableContainer` and `BaseEventTogglableContainer` implement the state machine; `BaseEventTogglableContainerComponent` bridges this into Unity's component lifecycle.
+
+### Activating a component
+
+Registering and decorating a building is not enough — every effect component starts **inactive** after `Awake` and will not run until something calls `Toggle(true)`. The caller is always consumer code, not the framework. Typical patterns:
+
+- **UI fragment** — a panel fragment (e.g. `DemoEnterableBuffFragment`) calls `component.Toggle(v)` from an `onValueChanged` callback, giving the player direct control.
+- **Game event / timer** — the component (or a sibling) calls `Toggle(false)` internally once a condition is met (e.g. the demo's auto-turn-off timer in `DemoEnterableBuffComponent.TickEffect`).
+- **Save / load** — persistent state restores the last active value via `Toggle` during `Load`, so the effect survives a reload.
+
+None of these are automatic. If you register a component but never call `Toggle(true)`, the effect will never run.
+
+---
+
+## Enterable effects
+
+These components apply an effect while a beaver (an `Enterer`) is physically inside an `Enterable` building. They live in [`EnterableSystem`](../../ModdableTimberborn/EnterableSystem/).
+
+There are two variants depending on how you want to drive the logic.
+
+### Event-driven: `TogglableEnterableEffectComponent`
+
+Fires a callback immediately when an enterer enters or exits. Suitable for one-shot changes (e.g. applying a bonus).
+
+```cs
+public abstract class TogglableEnterableEffectComponent
+    : BaseEventTogglableContainerComponent<TogglableEventEnterableContainer, Enterable, Enterer>
+{
+    protected abstract void OnEnter(Enterer enterer);
+    protected abstract void OnExit(Enterer enterer);
+}
+```
+
+When the component is toggled **on**, it subscribes to `Enterable.EntererAdded` / `EntererRemoved` and immediately calls `OnEnter` for every beaver already inside. Toggling **off** calls `OnExit` for current members and unsubscribes.
+
+For the common case of applying a `BonusTrackerItem`, skip this layer entirely and use the ready-made subclass:
+
+```cs
+public abstract class TogglableEnterableBonusComponent : TogglableEnterableEffectComponent
+{
+    protected abstract BonusTrackerItem Bonuses { get; }
+    // OnEnter → enterer.GetBonusTracker().AddOrUpdate(Bonuses)
+    // OnExit  → enterer.GetBonusTracker().Remove(Bonuses.Id)
+}
+```
+
+`TogglableEnterableBonusComponent` requires `ModdableTimberbornRegistry.Instance.UseBonusTracker(false)` to be called at startup (`false` = transient, not saved; use `UsePersistentBonusTracker()` / `UseBonusTracker(true)` if bonuses should survive reload).
+
+### Tick-driven: `TogglableEnterableTickEffectComponent`
+
+Runs `TickEffect()` on every game tick while the component is active. Use this when the effect accumulates over time (e.g. draining a need).
+
+```cs
+public abstract class TogglableEnterableTickEffectComponent : TickableComponent, ITogglableContainer<Enterable, Enterer>
+{
+    protected abstract void TickEffect();
+    public void Toggle(bool active) { ... }
+    // Also: Container, Members, Active, Toggled
+}
+```
+
+When you also need per-enterer state (e.g. a reference to each beaver's `NeedManager`), use the generic overload:
+
+```cs
+public abstract class TogglableEnterableTickEffectComponent<TData> : TogglableEnterableTickEffectComponent
+{
+    protected abstract TData GetData(Enterer enterer);
+
+    protected Dictionary<Enterer, TData> enterers;
+    public IReadOnlyCollection<KeyValuePair<Enterer, TData>> Enterers { get; }
+    public IReadOnlyCollection<TData> EnterersData { get; }
+}
+```
+
+The dictionary is kept in sync via `EntererAdded` / `EntererRemoved` regardless of the `Active` flag, so `EnterersData` always reflects current occupants. Only `TickEffect()` is gated on `Active`.
+
+> **Tick vs. event variant:** Unlike the event-driven `TogglableEnterableEffectComponent` — which subscribes to `EntererAdded`/`EntererRemoved` only while active and unsubscribes on deactivation — the tick component wires those subscriptions unconditionally in `Awake` and never tears them down. There is no `PerformActivate`/`PerformDeactivate` symmetry here; `TogglableEnterableContainer.PerformActivate` and `PerformDeactivate` are both no-ops. The `Active` flag only gates `Tick → TickEffect()`.
+
+> **`base.Awake()` requirement:** The generic subclass `TogglableEnterableTickEffectComponent<TData>` overrides `Awake` to wire those subscriptions. If you override `Awake` in your own subclass, you **must** call `base.Awake()` — otherwise `data` (and `Container`) will be `null` at runtime.
+
+### Registration
+
+Attach your component to every `Enterable` building via a template-module decorator in your configurator:
+
+```cs
+public class EnterableBuffConfig : IModdableTimberbornRegistryConfig
+{
+    public void Configure(Configurator configurator, ConfigurationContext context)
+    {
+        if (!context.IsGameContext()) { return; }
+
+        configurator
+            .BindTemplateModule(h => h
+                .AddDecorator<Enterable, MyEnterableBuffComponent>()
+            );
+    }
+}
+```
+
+### Demo example
+
+[`DemoEnterableBuffComponent`](../../ModdableTimberbornDemo/Features/EnterableBuff/DemoEnterableBuffComponent.cs) in the demo project uses `TogglableEnterableTickEffectComponent<NeedManager>` to apply a wet-fur need penalty to every beaver inside a building, with an auto-turn-off timer and save/load support:
+
+```cs
+public class DemoEnterableBuffComponent
+    : TogglableEnterableTickEffectComponent<NeedManager>, IPersistentEntity, IEntityEffectDescriber
+{
+    static readonly ContinuousEffect WetFurEffect = new("WetFur", .3f);
+
+    protected override NeedManager GetData(Enterer enterer)
+        => enterer.GetComponentFast<NeedManager>();
+
+    protected override void TickEffect()
+    {
+        // Auto-disable after a set time
+        if (turnOffAt <= dayNightCycle.PartialDayNumber)
+        {
+            Toggle(false);
+            return;
+        }
+
+        var time = dayNightCycle.FixedDeltaTimeInHours;
+        foreach (var needManager in EnterersData)
+            needManager.ApplyEffect(WetFurEffect, time);
+    }
+}
+```
+
+Registration is in [`EnterableBuffConfig`](../../ModdableTimberbornDemo/Features/EnterableBuff/EnterableBuffConfig.cs).
+
+---
+
+## Workplace effects
+
+These components apply an effect while a worker (`Worker`) is **assigned** to a `Workplace`. They live in [`WorkSystem`](../../ModdableTimberborn/WorkSystem/) and mirror the enterable pattern exactly.
+
+### `TogglableWorkplaceEffectComponent`
+
+Override `OnWorkerAssigned` and `OnWorkerUnassigned` for arbitrary effects:
+
+```cs
+public abstract class TogglableWorkplaceEffectComponent
+    : BaseEventTogglableContainerComponent<WorkplaceTogglableContainer, Workplace, Worker>
+{
+    protected abstract void OnWorkerAssigned(Worker worker);
+    protected abstract void OnWorkerUnassigned(Worker worker);
+}
+```
+
+When toggled **on**, it subscribes to `Workplace.WorkerAssigned` / `WorkerUnassigned` and immediately calls `OnWorkerAssigned` for every already-assigned worker. Deactivation mirrors this: current workers are unassigned and event handlers are removed.
+
+### `TogglableWorkplaceBonusComponent`
+
+For the bonus case, subclass this and supply a `BonusTrackerItem`:
+
+```cs
+public abstract class TogglableWorkplaceBonusComponent : TogglableWorkplaceEffectComponent
+{
+    protected abstract BonusTrackerItem Bonuses { get; }
+    // OnWorkerAssigned   → worker.GetBonusTracker().AddOrUpdate(Bonuses)
+    // OnWorkerUnassigned → worker.GetBonusTracker().Remove(Bonuses.Id)
+}
+```
+
+Requires `ModdableTimberbornRegistry.Instance.UseBonusTracker(false)` (or `UseBonusTracker(true)` / `UsePersistentBonusTracker()` for persistent bonuses).
+
+### Registration
+
+```cs
+public class WorkplaceBuffConfig : IModdableTimberbornRegistryConfig
+{
+    public void Configure(Configurator configurator, ConfigurationContext context)
+    {
+        if (!context.IsGameContext()) { return; }
+
+        configurator
+            .BindTemplateModule(h => h
+                .AddDecorator<Workplace, MyWorkplaceBuffComponent>()
+            );
+    }
+}
+```
+
+### Demo example
+
+[`DemoWorkplaceBuffComponent`](../../ModdableTimberbornDemo/Features/WorkplaceBuff/DemoWorkplaceBuffComponent.cs) applies movement-speed and working-speed bonuses to assigned workers:
+
+```cs
+public class DemoWorkplaceBuffComponent : TogglableWorkplaceBonusComponent, IEntityEffectDescriber
+{
+    static readonly BonusTrackerItem DemoBonuses = new("DemoWorkplaceBuff", [
+        BonusType.MovementSpeed.ToBonusSpec(1f),
+        new(BonusSystemHelpers.WorkingSpeedId, 1f),
+    ]);
+
+    protected override BonusTrackerItem Bonuses { get; } = DemoBonuses;
+
+    public EntityEffectDescription? Describe(ILoc t, IDayNightCycle dayNightCycle)
+        => Active
+            ? new("Demo Workplace Buff",
+                  t.T("LV.DemoMT.WorkplaceBuffDesc",
+                      DemoBonuses.Bonuses[0].MultiplierDelta,
+                      DemoBonuses.Bonuses[1].MultiplierDelta))
+            : null;
+}
+```
+
+Registration is in [`WorkplaceBuffConfig`](../../ModdableTimberbornDemo/Features/WorkplaceBuff/WorkplaceBuffConfig.cs).
+
+---
+
+## Soak effect
+
+The soak effect tracks **per-tick water exposure** for every `Character` in the game. Rather than each mod component sampling the water map itself, one shared `ModdableSoakEffectComponent` does the query once per tick and raises events that interested components subscribe to.
+
+### Enabling
+
+Call `UseSoakEffect()` from your `IModStarter` before any game context initialises:
+
+```cs
+ModdableTimberbornRegistry.Instance
+    .UseSoakEffect();
+```
+
+This registers `ModdableSoakEffectComponent` as a decorator on every `Character` prefab. The component is added once globally — calling `UseSoakEffect()` a second time is a no-op.
+
+### Subscribing
+
+Retrieve the component from the character and subscribe to one or both events:
+
+```cs
+var soakEffect = character.GetComponentFast<ModdableSoakEffectComponent>();
+
+// Fires every tick while the character is in water (even if water-resistant).
+soakEffect.OnSoakedTick += OnSoakedTick;
+
+// Fires when the character enters or leaves water.
+soakEffect.IsInWaterStateChanged += OnWaterStateChanged;
+```
+
+### `SoakEffectEventArgs`
+
+`OnSoakedTick` delivers a `SoakEffectEventArgs` value (a `readonly record struct`):
+
+| Member | Type | Description |
+|---|---|---|
+| `Resistant` | `bool` | True if a sibling `IWaterResistor` component reported the character as water-resistant. Check this before applying damage or debuffs. |
+| `WaterColumn` | `ReadOnlyWaterColumn` | Raw column data from the water map, including depth, contamination, and floor height. |
+| `Coordinate` | `Vector3Int` | The character's current grid coordinate. |
+| `WaterCeiling` | `int` | Pre-computed water surface z: `Ceil(depth + floor)`. |
+| `PassedTimeInHours` | `float` | Elapsed in-game time this tick (from `IDayNightCycle.FixedDeltaTimeInHours`). Use this to scale time-based effects. |
+
+`IsInWaterStateChanged` carries a plain `bool` — `true` when the character enters water, `false` when they leave. `ModdableSoakEffectComponent.IsInWater` also exposes the current state as a property (it is `false` when the character is resistant, even if physically submerged).
+
+### Example handler
+
+```cs
+void OnSoakedTick(object sender, SoakEffectEventArgs e)
+{
+    if (e.Resistant) { return; }
+
+    // Scale an effect by contamination level and elapsed time
+    var damage = e.WaterColumn.Contamination * e.PassedTimeInHours * DamageRate;
+    ApplyDamage(damage);
+}
+
+void OnWaterStateChanged(object sender, bool isInWater)
+{
+    if (isInWater)
+        StartWetAnimation();
+    else
+        StopWetAnimation();
+}
+```
+
+Source: [`ModdableSoakEffectComponent.cs`](../../ModdableTimberborn/SoakEffect/ModdableSoakEffectComponent.cs), [`ModdableSoakEffectConfig.cs`](../../ModdableTimberborn/SoakEffect/ModdableSoakEffectConfig.cs).

--- a/Docs/ModdableTimberborn/EntityTrackingAndStats.MD
+++ b/Docs/ModdableTimberborn/EntityTrackingAndStats.MD
@@ -302,7 +302,6 @@ public class MyHealthTracker(MyHealthComponent health, UpdatableEntityStatCompon
 **2. The stat factory** — extend `ComponentUpdatableEntityStatBase<T, TComp>` if your stat gates on a single component:
 
 ```cs
-// Registered automatically — no manual binding needed.
 public class MyHealthStat : ComponentUpdatableEntityStatBase<float, MyHealthComponent>
 {
     public override string Id => "MyHealth";
@@ -314,7 +313,13 @@ public class MyHealthStat : ComponentUpdatableEntityStatBase<float, MyHealthComp
 }
 ```
 
-Because `UpdatableEntityStatsConfig` discovers concrete `IUpdatableEntityStat` implementations via reflection at startup, **no manual DI binding is required**. Add the class and it is available through `UpdatableEntityStatService` immediately.
+`UpdatableEntityStatsConfig` discovers `IUpdatableEntityStat` implementations via reflection at startup — but only within the **ModdableTimberborn** assembly (`Assembly.GetExecutingAssembly()`). A stat you define in your own mod assembly is **not** discovered automatically; multibind it in your configurator:
+
+```cs
+configurator.MultiBind<IUpdatableEntityStat>().To<MyHealthStat>().AsSingleton();
+```
+
+Once bound, it is available through `UpdatableEntityStatService`.
 
 For a percent stat (displayed as `"P0"`), extend `ComponentUpdatableEntityPercentStatBase<TComp>` and implement `GetComponentPercentTracker` instead. The tracker should extend `StatPercentTrackerBase`.
 

--- a/Docs/ModdableTimberborn/EntityTrackingAndStats.MD
+++ b/Docs/ModdableTimberborn/EntityTrackingAndStats.MD
@@ -1,0 +1,371 @@
+# Entity Tracking & Stats
+
+This page covers two related subsystems:
+
+- **Entity Tracker** — maintains live, categorised sets of in-game entities so your code can query "all adults" or "all workplaces" without walking the full entity list.
+- **Updatable Entity Stats** — attaches observable, pausable stat trackers to entities so UI panels can react to value changes without polling.
+
+Both subsystems are opt-in and are activated independently from your `IModStarter`.
+
+---
+
+## Entity Tracker
+
+### Enabling
+
+Call `UseEntityTracker()` on the registry before any configurators run:
+
+```cs
+public class MStarter : IModStarter
+{
+    void IModStarter.StartMod(IModEnvironment modEnvironment)
+    {
+        ModdableTimberbornRegistry.Instance
+            .UseEntityTracker()
+            .AddConfigurator<MyGameConfig>();
+    }
+}
+```
+
+`UseEntityTracker()` is idempotent — calling it more than once is safe.
+
+### What you get out of the box
+
+Two specialised trackers are always registered when the subsystem is enabled:
+
+#### `CharacterTracker`
+
+Tracks every character entity and routes them into typed sets. Inject it anywhere in a Game context:
+
+```cs
+public class MyService(CharacterTracker characterTracker)
+{
+    public void DoWork()
+    {
+        // Pre-split sets — no LINQ required
+        foreach (var adult in characterTracker.Adults)   { /* CharacterTrackerComponent */ }
+        foreach (var child in characterTracker.Children) { /* CharacterTrackerComponent */ }
+        foreach (var bot   in characterTracker.Bots)     { /* CharacterTrackerComponent */ }
+
+        // Convenience enumerables
+        foreach (var beaver in characterTracker.Beavers)  { /* adults + children */ }
+        foreach (var worker in characterTracker.Workers)  { /* adults + bots */ }
+    }
+}
+```
+
+Filter by flag combination using `GetCharacters`:
+
+```cs
+// Iterate all adult beavers and bots together
+foreach (var c in characterTracker.GetCharacters(CharacterType.AdultBeaver | CharacterType.Bot))
+{
+    // c is CharacterTrackerComponent
+}
+
+// Project directly to another component type
+foreach (var hunger in characterTracker.GetCharacters<Hunger>(CharacterType.AdultBeaver))
+{
+    // hunger is Hunger
+}
+```
+
+`CharacterTrackerComponent` is the payload attached to each character. Key members:
+
+| Member | Type | Notes |
+|---|---|---|
+| `CharacterType` | `CharacterType` | `AdultBeaver`, `ChildBeaver`, or `Bot` |
+| `Worker` | `Worker?` | Null for children and some bots |
+| `IsAdult` / `IsChild` / `IsBot` / `IsBeaver` / `IsWorker` | `bool` | Convenience flags |
+| `BonusTracker` | `BonusTracker?` | Present when the Bonus System is also enabled |
+| `HasBonus(string id)` | `bool` | Shorthand for checking an active named bonus |
+
+#### `WorkplaceTracker`
+
+Tracks every entity that carries a `Workplace` component:
+
+```cs
+public class MyService(WorkplaceTracker workplaceTracker)
+{
+    public void DoWork()
+    {
+        foreach (var wp in workplaceTracker.Entities)
+        {
+            // wp is WorkplaceTrackerComponent
+            // wp.Workplace     — the Timberborn Workplace component
+            // wp.TemplateName  — prefab template name
+            // wp.IsBuilderWorkplace
+        }
+
+        // Filtered view — builder workplaces only
+        foreach (var bw in workplaceTracker.BuilderWorkplaces) { }
+    }
+}
+```
+
+`WorkplaceTracker` also forwards worker-assignment events from the underlying `Workplace` component so you do not have to subscribe to each building individually:
+
+```cs
+workplaceTracker.OnWorkerAssigned   += (comp, worker) => { /* ... */ };
+workplaceTracker.OnWorkerUnassigned += (comp, worker) => { /* ... */ };
+```
+
+### Tracking a custom component type
+
+To maintain a live set for any `BaseComponent` you define, call `TryTrack<T>()` during bootstrap:
+
+```cs
+ModdableTimberbornRegistry.Instance
+    .UseEntityTracker()
+    .TryTrack<MyBuildingComponent>();
+```
+
+This registers a `DefaultEntityTracker<MyBuildingComponent>` singleton. Inject it wherever you need the live set:
+
+```cs
+public class MyService(DefaultEntityTracker<MyBuildingComponent> tracker)
+{
+    public void DoWork()
+    {
+        foreach (var comp in tracker.Entities) { /* ... */ }
+    }
+}
+```
+
+You can also react to entities arriving and leaving:
+
+```cs
+tracker.OnEntityRegistered   += comp => { /* entity appeared */ };
+tracker.OnEntityUnregistered += comp => { /* entity removed  */ };
+```
+
+`TryTrack<T>` throws `InvalidOperationException` if you pass a type that is already covered by a built-in tracker (`Character`, `WorkplaceSpec`, and their related types). Check the error message — it names the tracker you should inject instead.
+
+### How tracking works internally
+
+`EntityTrackerController` is a singleton that subscribes to `EntityInitializedEvent` and `EntityDeletedEvent` via the Timberborn `EventBus`. On each event it iterates every registered `IEntityTracker` and calls `Track` or `Untrack`. Each tracker calls `entity.GetComponent<T>()` internally and silently skips entities that do not carry the expected component, so the fan-out is safe regardless of entity type.
+
+### The `IEntityTracker<T>` interface
+
+If you inject by interface rather than concrete type, the contract is:
+
+```cs
+public interface IEntityTracker<T> : IEntityTracker where T : BaseComponent
+{
+    IReadOnlyCollection<T> Entities { get; }
+    event Action<T>? OnEntityRegistered;
+    event Action<T>? OnEntityUnregistered;
+}
+```
+
+Source: [`../../ModdableTimberborn/EntityTracker/IEntityTracker.cs`](../../ModdableTimberborn/EntityTracker/IEntityTracker.cs)
+
+---
+
+## Updatable Entity Stats
+
+### Enabling
+
+```cs
+ModdableTimberbornRegistry.Instance
+    .UseUpdatableEntityStats()
+    .AddConfigurator<MyGameConfig>();
+```
+
+Like all `Use…()` calls this is idempotent and chainable.
+
+### Core concepts
+
+Each *stat* is a singleton factory (`IUpdatableEntityStat`) that knows how to create a *tracker* (`IEntityStatTracker`) for one specific entity. The tracker is the live, observable object: it fires `OnValueChanged` whenever the underlying game state changes and can be paused when the owning UI panel is not visible.
+
+In a Game context, every entity automatically carries an `UpdatableEntityStatComponent` (added as a decorator on every `TemplateSpec` — the decorator registration is guarded by `if (!context.IsGameContext()) return;` in `UpdatableEntityStatsConfig`). Trackers self-register with this component on construction, so when the entity is deleted the component calls `NotifyEntityLost` and disposes all trackers for you.
+
+### Built-in stats
+
+`UpdatableEntityStatService` aggregates every `IUpdatableEntityStat` in the assembly. Inject it to discover what is available:
+
+```cs
+public class MyPanel(UpdatableEntityStatService statService) { }
+```
+
+| Id | C# type | Value type | Driven by |
+|---|---|---|---|
+| `"Name"` | `NameStat` | `string` | `NamedEntity.EntityNameChanged` |
+| `"Avatar"` | `AvatarStat` | `Sprite?` | `Contaminable.ContaminationChanged` |
+| `"ProductionPercent"` | `ProductionPercentStat` | `float` (%) | `Manufactory.ProductionProgressed` |
+| `"RecipeIcon"` | `RecipeIconStat` | `Sprite?` | `Manufactory.RecipeChanged` |
+| `"StorageStock"` | `InventoryStockStat` | `int` | `Inventory.InventoryChanged` |
+| `"StorageStockMax"` | `InventoryStockMax` | `int` | `Inventory.InventoryChanged` |
+| `"StoragePercent"` | `InventoryPercent` | `float` (%) | `Inventory.InventoryChanged` |
+| `"StockpileIcon"` | `StockpileIconStat` | `Sprite?` | `SingleGoodAllower.DisallowedGoodsChanged` |
+| `"Population"` | `PopulationStat` | `int` | `PopulationStatService.OnPopulationChanged` |
+
+Percent stats format `ValueFormatted` as `"P0"` (e.g. `"42 %"`). Image stats expose `Sprite?`; check for null before assigning to a UI element.
+
+### Using a stat in a UI panel
+
+The typical pattern for a panel that opens on a selected entity:
+
+```cs
+public class MyEntityPanel(UpdatableEntityStatService statService)
+{
+    IEntityStatTracker<string>? _nameTracker;
+
+    public void ShowEntity(UpdatableEntityStatComponent entityStatComp)
+    {
+        // Look up the stat factory by id (or inject NameStat directly)
+        if (!statService.TryGetStat("Name", out var stat)) { return; }
+        if (!stat.TryGetTracker(entityStatComp, out var tracker)) { return; }
+
+        _nameTracker = (IEntityStatTracker<string>)tracker;
+        _nameTracker.OnValueChanged += OnNameChanged;
+        _nameTracker.OnEntityLost   += OnEntityLost;
+        _nameTracker.Start();
+
+        // ForceUpdating() raises OnValueChanged even if the value has not changed,
+        // useful to populate the UI on first open.
+        _nameTracker.ForceUpdating();
+    }
+
+    public void HidePanel()
+    {
+        _nameTracker?.Pause();
+        // or Dispose() if you will create a fresh tracker next time
+    }
+
+    void OnNameChanged(object sender, EventArgs e)
+        => nameLabel.text = _nameTracker!.ValueFormatted;
+
+    void OnEntityLost(object sender, UpdatableEntityStatComponent e)
+        => HidePanel();
+}
+```
+
+Key points:
+- `TryGetTracker` returns `false` when the entity does not support the stat (e.g. asking for `"ProductionPercent"` on a stockpile). Always guard the return value.
+- The tracker constructor registers itself with `UpdatableEntityStatComponent` immediately, so call `Dispose()` if you decide not to use a tracker you created.
+- `Pause()` unsubscribes from game events without disposing. `Start()` re-subscribes and calls `UpdateValue()` once.
+- To enumerate all available stats, use `statService.AllStats` (every registered `IUpdatableEntityStat`), `statService.AllImageStats` (subset of `IImageStat`), or `statService.AllPercentStats` (subset of `IPercentStat`).
+
+### The `IStatTracker` contract
+
+```cs
+public interface IStatTracker : IDisposable  // Dispose() comes from IDisposable
+{
+    void Start();
+    void Pause();
+    bool Running { get; }
+    void ForceUpdating();
+    string ValueFormatted { get; }
+    event EventHandler? OnValueChanged;
+}
+
+public interface IStatTracker<T> : IStatTracker
+{
+    T? Value { get; }
+    event EventHandler<T?>? OnTypedValueChanged;
+}
+
+public interface IEntityStatTracker : IStatTracker
+{
+    UpdatableEntityStatComponent Component { get; }
+    void NotifyEntityLost();
+    event EventHandler<UpdatableEntityStatComponent>? OnEntityLost;
+}
+```
+
+Source: [`../../ModdableTimberborn/UpdatableEntityStats/IEntityStatTracker.cs`](../../ModdableTimberborn/UpdatableEntityStats/IEntityStatTracker.cs)
+
+### Writing a custom stat
+
+Implement `IUpdatableEntityStat` and a paired tracker. The fastest route is to extend the provided base classes:
+
+**1. The tracker** — extend `StatTrackerBase<T>` and implement three abstract members:
+
+```cs
+public class MyHealthTracker(MyHealthComponent health, UpdatableEntityStatComponent comp)
+    : StatTrackerBase<float>(comp)  // registers with comp immediately
+{
+    protected override void OnStart()
+        => health.HealthChanged += OnHealthChanged;
+
+    protected override void OnPause()
+        => health.HealthChanged -= OnHealthChanged;
+
+    protected override float CalculateValue()
+        => health.CurrentHealth / health.MaxHealth;
+
+    void OnHealthChanged(object sender, EventArgs e) => UpdateValue();
+}
+```
+
+**2. The stat factory** — extend `ComponentUpdatableEntityStatBase<T, TComp>` if your stat gates on a single component:
+
+```cs
+// Registered automatically — no manual binding needed.
+public class MyHealthStat : ComponentUpdatableEntityStatBase<float, MyHealthComponent>
+{
+    public override string Id => "MyHealth";
+    // DisplayLoc defaults to "LV.MT.UStat.MyHealth"
+
+    protected override IEntityStatTracker<float>? GetComponentTracker(
+        UpdatableEntityStatComponent statComp, MyHealthComponent comp)
+        => new MyHealthTracker(comp, statComp);
+}
+```
+
+Because `UpdatableEntityStatsConfig` discovers concrete `IUpdatableEntityStat` implementations via reflection at startup, **no manual DI binding is required**. Add the class and it is available through `UpdatableEntityStatService` immediately.
+
+For a percent stat (displayed as `"P0"`), extend `ComponentUpdatableEntityPercentStatBase<TComp>` and implement `GetComponentPercentTracker` instead. The tracker should extend `StatPercentTrackerBase`.
+
+### Population stat
+
+`PopulationStat` has a slightly richer API because population can be scoped to a district or reported globally, and the mode (adult count, total, capacity, etc.) is configurable at call time.
+
+```cs
+public class MyWidget(UpdatableEntityStatService statService)
+{
+    // District-bound (entity must have DistrictCenter)
+    public void TrackDistrict(UpdatableEntityStatComponent districtComp)
+    {
+        var opts = new PopulationCounterOptions(
+            PopulationCounterMode.Adults,
+            CountBeavers: true,
+            CountBots: false);
+
+        statService.PopulationStat.TryGetTracker(opts, districtComp, out var tracker);
+        tracker?.Start();
+    }
+
+    // Global (not entity-bound — caller owns disposal)
+    public void TrackGlobal()
+    {
+        var opts = new PopulationCounterOptions(PopulationCounterMode.Adults, true, false);
+        var tracker = statService.PopulationStat.GetGlobalTracker(opts);
+        tracker.Start();
+        // Must call tracker.Dispose() manually when done.
+    }
+}
+```
+
+`GlobalPopulationStatTracker` does not attach to any entity, so it is never cleaned up automatically — dispose it yourself when the UI element is closed.
+
+---
+
+## Source files
+
+| File | Purpose |
+|---|---|
+| [`../../ModdableTimberborn/EntityTracker/EntityTrackerConfig.cs`](../../ModdableTimberborn/EntityTracker/EntityTrackerConfig.cs) | DI wiring + `UseEntityTracker()` / `TryTrack<T>()` registry extensions |
+| [`../../ModdableTimberborn/EntityTracker/EntityTrackerController.cs`](../../ModdableTimberborn/EntityTracker/EntityTrackerController.cs) | Event-bus listener; fans out to all `IEntityTracker` instances |
+| [`../../ModdableTimberborn/EntityTracker/IEntityTracker.cs`](../../ModdableTimberborn/EntityTracker/IEntityTracker.cs) | `IEntityTracker` and `IEntityTracker<T>` interfaces |
+| [`../../ModdableTimberborn/EntityTracker/DefaultEntityTracker.cs`](../../ModdableTimberborn/EntityTracker/DefaultEntityTracker.cs) | Generic tracker used for `TryTrack<T>()` registrations |
+| [`../../ModdableTimberborn/EntityTracker/CharacterTracker.cs`](../../ModdableTimberborn/EntityTracker/CharacterTracker.cs) | Built-in character tracker (adults / children / bots) |
+| [`../../ModdableTimberborn/EntityTracker/WorkplaceTracker.cs`](../../ModdableTimberborn/EntityTracker/WorkplaceTracker.cs) | Built-in workplace tracker |
+| [`../../ModdableTimberborn/EntityTracker/Components/`](../../ModdableTimberborn/EntityTracker/Components/) | `CharacterTrackerComponent` and `WorkplaceTrackerComponent` |
+| [`../../ModdableTimberborn/UpdatableEntityStats/UpdatableEntityStatsConfig.cs`](../../ModdableTimberborn/UpdatableEntityStats/UpdatableEntityStatsConfig.cs) | DI wiring + `UseUpdatableEntityStats()` registry extension |
+| [`../../ModdableTimberborn/UpdatableEntityStats/IUpdatableEntityStat.cs`](../../ModdableTimberborn/UpdatableEntityStats/IUpdatableEntityStat.cs) | Stat factory interfaces |
+| [`../../ModdableTimberborn/UpdatableEntityStats/IEntityStatTracker.cs`](../../ModdableTimberborn/UpdatableEntityStats/IEntityStatTracker.cs) | Tracker lifecycle interfaces |
+| [`../../ModdableTimberborn/UpdatableEntityStats/UpdatableEntityStatComponent.cs`](../../ModdableTimberborn/UpdatableEntityStats/UpdatableEntityStatComponent.cs) | Per-entity tracker registry; handles entity deletion |
+| [`../../ModdableTimberborn/UpdatableEntityStats/UpdatableEntityStatService.cs`](../../ModdableTimberborn/UpdatableEntityStats/UpdatableEntityStatService.cs) | Singleton aggregating all registered stats |
+| [`../../ModdableTimberborn/UpdatableEntityStats/Implementations/`](../../ModdableTimberborn/UpdatableEntityStats/Implementations/) | All built-in stat + tracker pairs; base classes |

--- a/Docs/ModdableTimberborn/GameStats.MD
+++ b/Docs/ModdableTimberborn/GameStats.MD
@@ -1,0 +1,165 @@
+# Game Stats
+
+Game Stats is a string-keyed registry of global game statistics. It decouples consumers — UI, condition checks, dynamic text — from Timberborn's individual data services. Any stat can be queried by name without a direct code dependency on the provider that supplies it.
+
+## Enabling Game Stats
+
+Call `UseGameStats()` on your `ModdableTimberbornRegistry` instance during plugin setup:
+
+```cs
+ModdableTimberbornRegistry.Instance.UseGameStats();
+```
+
+This registers [`GameStatsConfig`](../../ModdableTimberborn/GameStats/GameStatsConfig.cs) with the registry, which auto-discovers all built-in providers and binds [`GameStatService`](../../ModdableTimberborn/GameStats/GameStatService.cs) as a singleton.
+
+## Reading a stat
+
+Inject `GameStatService` and call one of its lookup methods:
+
+```cs
+// Untyped — returns object?
+object? raw = statService.GetStat("TotalPopulation");
+
+// Typed — throws InvalidCastException on type mismatch
+int pop = statService.GetStat<int>("TotalPopulation");
+
+// Safe typed — returns false if the key is missing or the type doesn't match
+if (statService.TryGetStat<int>("TotalPopulation", out var pop))
+{
+    // use pop
+}
+
+// Pre-formatted string (e.g. "42 %" for percent stats)
+string display = statService.GetStatFormatted("BeaverPercent");
+```
+
+Duplicate stat IDs across providers throw immediately at load — this is intentional. Unknown keys throw `KeyNotFoundException` on all methods except `TryGetStat`, which returns `false`.
+
+`GameStatService` also exposes two provider-lookup methods:
+
+- `GetProvider(string stat)` — returns the `IGameStatProvider` registered for that key; throws `KeyNotFoundException` if the key is unknown.
+- `GetProvider<T>(string stat)` — same, but casts the provider to `T`; throws `KeyNotFoundException` on an unknown key and `InvalidCastException` if the provider does not implement `T`.
+
+## Built-in stat keys
+
+### Population counts (`int`)
+
+Provided by [`GlobalPopulationStatsProvider`](../../ModdableTimberborn/GameStats/Implementations/GlobalPopulationStatsProvider.cs).
+
+| Key | Description |
+|---|---|
+| `NumberOfAdults` | Adult beavers |
+| `NumberOfChildren` | Beaver children |
+| `NumberOfBots` | Bots |
+| `NumberOfBeavers` | All beavers (adults + children) |
+| `NumberOfHealthyAdults` | Healthy adult beavers |
+| `NumberOfHealthyChildren` | Healthy beaver children |
+| `TotalPopulation` | All beavers and bots combined |
+| `OccupiedBeds` | Beds currently occupied |
+| `FreeBeds` | Unoccupied beds |
+| `TotalBeds` | Occupied + free beds |
+| `Homeless` | Beavers without a bed |
+| `ContaminatedAdults` | Contaminated adult beavers |
+| `ContaminatedChildren` | Contaminated beaver children |
+| `ContaminatedTotal` | All contaminated beavers |
+
+#### Workforce counts (`int`)
+
+Unprefixed keys return the combined beaver + bot total. Prefix with `Beavers` or `Bot` for per-type values.
+
+| Key | `Beavers` variant | `Bot` variant |
+|---|---|---|
+| `Employable` | `BeaversEmployable` | `BotEmployable` |
+| `Unemployable` | `BeaversUnemployable` | `BotUnemployable` |
+| `Total` | `BeaversTotal` | `BotTotal` |
+
+### Population ratios (`float`, formatted as percentage)
+
+Provided by [`GlobalPopulationPercentStatsProvider`](../../ModdableTimberborn/GameStats/Implementations/GlobalPopulationPercentStatsProvider.cs). All values are floats in the range 0–1; `GetStatFormatted` renders them as `"P0"` strings (e.g. `"42 %"`), or `"N/A"` for negative values.
+
+| Key | Ratio |
+|---|---|
+| `BeaverPercent` | Beavers as a share of total population |
+| `BotPercent` | Bots as a share of total population |
+| `AdultPercent` | Adults as a share of beavers |
+| `ChildPercent` | Children as a share of beavers |
+| `HomelessPercent` | Homeless as a share of beavers |
+| `AdultContaminatedPercent` | Contaminated adults as a share of beavers |
+| `ChildContaminatedPercent` | Contaminated children as a share of beavers |
+| `ContaminatedPercent` | All contaminated as a share of beavers |
+
+### Per-good stats
+
+Good IDs match the Timberborn good identifier strings (e.g. `Wood`, `Water`, `Plank`).
+
+#### Amounts and capacity (`int`)
+
+Provided by [`GoodStatsProvider`](../../ModdableTimberborn/GameStats/Implementations/GoodStatsProvider.cs).
+
+| Key pattern | Description |
+|---|---|
+| `GoodAmount.<goodId>` | Global available stock of the good |
+| `GoodCapacity.<goodId>` | Global input/output storage capacity |
+
+Example: `"GoodAmount.Wood"`, `"GoodCapacity.Water"`.
+
+#### Fill rate (`float`, formatted as percentage)
+
+Provided by [`GoodPercentStatsProvider`](../../ModdableTimberborn/GameStats/Implementations/GoodPercentStatsProvider.cs).
+
+| Key pattern | Description |
+|---|---|
+| `GoodFill.<goodId>` | Storage fill rate (0–1) |
+
+Example: `"GoodFill.Plank"`.
+
+The good-keyed stats are snapshotted at load time from `IGoodService.Goods`. Goods introduced after load will not be present.
+
+## Providing a custom stat
+
+Implement [`IGameStatProvider`](../../ModdableTimberborn/GameStats/IGameStatProvider.cs) (or one of its typed sub-interfaces) and register it with the DI container.
+
+### Choosing an interface
+
+| Interface | Value type | Notes |
+|---|---|---|
+| `IIntGameStatProvider` | `int` | |
+| `IFloatGameStatProvider` | `float` | |
+| `IStringGameStatProvider` | `string` | |
+| `ISpriteGameStatProvider` | `Sprite?` | |
+| `IPercentGameStatProvider` | `float` | `GetStatFormatted` renders as `"P0"` percentage, or `"N/A"` for negative values |
+| `IGameStatProvider<T>` | any `T` | Use when none of the above fit |
+
+### Implementing a provider
+
+```cs
+public class MyModStatsProvider : IIntGameStatProvider
+{
+    // All stat IDs this provider owns. Must be globally unique.
+    public IEnumerable<string> AvailableStats => ["MyMod.SomeCount", "MyMod.OtherCount"];
+
+    public int? GetStat(string statId) => statId switch
+    {
+        "MyMod.SomeCount"  => ComputeSomeCount(),
+        "MyMod.OtherCount" => ComputeOtherCount(),
+        _ => throw new ArgumentOutOfRangeException(nameof(statId)),
+    };
+}
+```
+
+Use a unique prefix (e.g. your mod name) to avoid collisions with other providers. A duplicate key detected at load throws immediately.
+
+### Registering the provider
+
+Auto-discovery via `GameStatsConfig` only scans the `ModdableTimberborn` assembly itself. Providers in your own assembly must be registered manually:
+
+```cs
+[Context("Game")]
+public class MyGameConfig : Configurator
+{
+    public override void Configure()
+    {
+        MultiBind<IGameStatProvider>().To<MyModStatsProvider>().AsSingleton();
+    }
+}
+```

--- a/Docs/ModdableTimberborn/MechanicalSystem.MD
+++ b/Docs/ModdableTimberborn/MechanicalSystem.MD
@@ -1,0 +1,187 @@
+# Mechanical System
+
+The Mechanical System subsystem makes a building's nominal power input and output runtime-moddable. Without it, those values are fixed at prefab-load time and cannot be changed by mods. Enabling the subsystem wraps every `MechanicalNode` in a decorator that runs a modifier pipeline, pushes recalculated values back into Timberborn's original component, and fires a change event for any downstream listeners (UI, logic, etc.).
+
+## Enabling the subsystem
+
+Call `UseMechanicalSystem()` on the shared registry inside your plugin's `Configure` method before the game context is built. The method is idempotent — calling it more than once is safe.
+
+```cs
+ModdableTimberbornRegistry.Instance
+    .UseMechanicalSystem();
+```
+
+Source: [`ModdableMechanicalSystemConfig.cs`](../../ModdableTimberborn/MechanicalSystem/ModdableMechanicalSystemConfig.cs)
+
+## Key types
+
+| Type | Role |
+|---|---|
+| [`ModdableMechanicalNode`](../../ModdableTimberborn/MechanicalSystem/ModdableMechanicalNode.cs) | Decorator attached to every `MechanicalNode`. Owns the modifier collection, recalculates on dirty, and pushes updated values back into the wrapped node. |
+| [`MechanicalNodeValues`](../../ModdableTimberborn/MechanicalSystem/MechanicalNodeValues.cs) | `readonly record struct` with two fields: `NominalInput` and `NominalOutput`. |
+| [`ModdableMechanicalNodeValues`](../../ModdableTimberborn/MechanicalSystem/MechanicalNodeValues.cs) | `ModdableValue<MechanicalNodeValues>` wrapper passed through the modifier chain; exposes both the current (mutable) value and the original prefab value. |
+| [`IModdableMechanicalNodeModifier`](../../ModdableTimberborn/MechanicalSystem/IModdableMechanicalNodeModifier.cs) | Interface your modifier component must implement. |
+
+`MechanicalNodeModifierCollection` is a type alias for `ValueModifierCollection<IModdableMechanicalNodeModifier, ModdableMechanicalNodeValues, MechanicalNodeValues>` (defined in `zGlobalUsings.cs`).
+
+## Writing a power modifier
+
+A modifier is a `BaseComponent` (a Timberborn MonoBehaviour-like base) that implements `IModdableMechanicalNodeModifier`. The interface requires:
+
+| Member | Purpose |
+|---|---|
+| `string Id { get; }` | Unique identifier for this modifier. |
+| `int Priority { get; }` | Execution order — lower values run first. Use `ModifierPriority` enum values as a guide. |
+| `bool Disabled { get; }` | When `true` the collection skips this modifier entirely. |
+| `event Action? OnChanged` | Fire this whenever the modifier's state changes; the collection reacts by recalculating. |
+| `bool Modify(ModdableMechanicalNodeValues value)` | Apply the modification in-place. Return `true` to short-circuit remaining modifiers, `false` to continue. |
+
+`ModifierPriority` values: `Force = -1000`, `Additive = 0`, `Multiplicative = 1000`.
+
+### Worked example
+
+The demo project provides three modifier variants — additive, multiplicative, and force — built on a shared abstract base. The full source is at [`DemoMechanicalSystemModifier.cs`](../../ModdableTimberbornDemo/Features/MechanicalSystem/DemoMechanicalSystemModifier.cs).
+
+```cs
+// Shared base — handles Disabled/Amount state and fires OnChanged.
+public abstract class BaseDemoMechanicalModifier : BaseComponent, IModdableMechanicalNodeModifier
+{
+    public abstract string Id { get; }
+    public abstract int Priority { get; }
+    protected bool ShouldShortCircuit { get; set; }
+
+    public bool Disabled
+    {
+        get;
+        set
+        {
+            if (value != field) { field = value; OnChanged?.Invoke(); }
+        }
+    } = true;
+
+    public float Amount
+    {
+        get;
+        set
+        {
+            if (value != field) { field = value; OnChanged?.Invoke(); }
+        }
+    }
+
+    public event Action? OnChanged;
+
+    public bool Modify(ModdableMechanicalNodeValues value)
+    {
+        var (curr, original) = value;
+
+        // Only scale values that were non-zero on the original prefab.
+        if (original.NominalInput != 0)
+            value.Value = curr with { NominalInput = ModifyValue(curr.NominalInput) };
+
+        if (original.NominalOutput != 0)
+            value.Value = curr with { NominalOutput = ModifyValue(curr.NominalOutput) };
+
+        return ShouldShortCircuit;
+    }
+
+    protected abstract int ModifyValue(int currValue);
+}
+
+// Additive modifier — priority 0; runs after Force (priority -1000).
+public class DemoAdditiveMechanicalSystemModifier : BaseDemoMechanicalModifier
+{
+    public override string Id { get; } = nameof(DemoAdditiveMechanicalSystemModifier);
+    public override int Priority { get; } = (int)ModifierPriority.Additive;
+
+    protected override int ModifyValue(int currValue) => Mathf.RoundToInt(currValue + Amount);
+}
+
+// Multiplicative modifier — runs after additive (priority 1000).
+public class DemoMultiplicativeMechanicalSystemModifier : BaseDemoMechanicalModifier
+{
+    public override string Id { get; } = nameof(DemoMultiplicativeMechanicalSystemModifier);
+    public override int Priority { get; } = (int)ModifierPriority.Multiplicative;
+
+    protected override int ModifyValue(int currValue) => Mathf.RoundToInt(currValue * Amount);
+}
+
+// Force modifier — short-circuits the chain (priority -1000).
+public class DemoForceMechanicalSystemModifier : BaseDemoMechanicalModifier
+{
+    public override string Id { get; } = nameof(DemoForceMechanicalSystemModifier);
+    public override int Priority { get; } = (int)ModifierPriority.Force;
+
+    protected override int ModifyValue(int currValue) => Mathf.RoundToInt(Amount);
+
+    public DemoForceMechanicalSystemModifier() { ShouldShortCircuit = true; }
+}
+```
+
+Two runtime behaviours to keep in mind:
+
+- **Modifiers start disabled.** The demo base class initialises `Disabled = true`, so a freshly registered modifier has no effect until your code sets `Disabled = false`. This matches the interface contract (`Disabled { get; }` — the collection skips disabled modifiers).
+- **Chain resets before applying.** On every recalculation `ValueModifierCollection` resets `value.Value` to `value.OriginalValue` before iterating modifiers (`ValueModifierCollection.cs:23`). This means the modifier chain always starts from the prefab value, which is why additive and multiplicative ordering matters — a multiplicative modifier sees the additive-adjusted value, not the raw original.
+
+### Registering modifiers
+
+Add your modifier components as decorators on `MechanicalNode` via `BindTemplateModule`. Each instance is colocated on the same GameObject as the `MechanicalNode` it modifies. See [`MechanicalSystemConfig.cs`](../../ModdableTimberbornDemo/Features/MechanicalSystem/MechanicalSystemConfig.cs) in the demo:
+
+```cs
+public class MechanicalSystemConfig : IModdableTimberbornRegistryConfig
+{
+    public void Configure(Configurator configurator, ConfigurationContext context)
+    {
+        configurator
+            .BindFragment<DemoMechanicalSystemFragment>()
+
+            .BindTemplateModule(h => h
+                .AddDecorator<MechanicalNode, DemoAdditiveMechanicalSystemModifier>()
+                .AddDecorator<MechanicalNode, DemoMultiplicativeMechanicalSystemModifier>()
+                .AddDecorator<MechanicalNode, DemoForceMechanicalSystemModifier>()
+            );
+    }
+}
+```
+
+Pass this config to the registry:
+
+```cs
+ModdableTimberbornRegistry.Instance
+    .UseMechanicalSystem()
+    .AddConfigurator(new MechanicalSystemConfig());
+```
+
+## Reacting to value changes
+
+`ModdableMechanicalNode` exposes an event you can subscribe to from UI fragments or other components:
+
+```cs
+var mechNode = entity.GetComponentFast<ModdableMechanicalNode>();
+mechNode.OnMechanicalNodeValuesChanged += (_, e) =>
+{
+    // e.OldValue and e.NewValue are both MechanicalNodeValues
+    Debug.Log($"Input: {e.OldValue.NominalInput} -> {e.NewValue.NominalInput}");
+};
+```
+
+The current and original values are also available at any time via `mechNode.MechanicalNodeValues`. See [`DemoMechanicalSystemFragment.cs`](../../ModdableTimberbornDemo/Features/MechanicalSystem/DemoMechanicalSystemFragment.cs) for a full UI example that hides the panel when the node has zero input and output:
+
+```cs
+var (input, output) = mechNode.MechanicalNodeValues.OriginalValue;
+if (input == 0 && output == 0)
+{
+    ClearFragment();
+    return;
+}
+```
+
+## Harmony patches
+
+Enabling the subsystem also applies two Harmony patches (category `ModdableTimberborn.MechanicalSystem`). Both fix vanilla edge cases that surface when power values become dynamic:
+
+- **`MechanicalGraphPatches`** — Adds a postfix to the `MechanicalGraph.Powered` getter. Vanilla returns `false` when `PowerDemand == 0`; the patch forces `true` in that case so networks with no consumers are not incorrectly treated as unpowered.
+- **`MechanicalNodePatches`** — Adds a prefix to `MechanicalNode.CanPotentiallyBePowered` that returns `true` for any node whose nominal input is zero or below, bypassing the vanilla `NoPowerStatus` check.
+
+Both patches are global — they affect all mechanical nodes and graphs, not only those with active modifiers.
+
+Source: [`Patches/MechanicalGraphPatches.cs`](../../ModdableTimberborn/MechanicalSystem/Patches/MechanicalGraphPatches.cs), [`Patches/MechanicalNodePatches.cs`](../../ModdableTimberborn/MechanicalSystem/Patches/MechanicalNodePatches.cs)

--- a/Docs/ModdableTimberborn/MechanicalSystem.MD
+++ b/Docs/ModdableTimberborn/MechanicalSystem.MD
@@ -4,11 +4,14 @@ The Mechanical System subsystem makes a building's nominal power input and outpu
 
 ## Enabling the subsystem
 
-Call `UseMechanicalSystem()` on the shared registry inside your plugin's `Configure` method before the game context is built. The method is idempotent — calling it more than once is safe.
+Enable the subsystem at **mod startup** — `Use…()` opt-ins run before the Bindito contexts are built, so call it from your config's `StartMod` (a `BaseModdableTimberbornConfiguration` subclass), *not* from `Configure`. The method is idempotent — calling it more than once is safe.
 
 ```cs
-ModdableTimberbornRegistry.Instance
-    .UseMechanicalSystem();
+public override void StartMod(IModEnvironment modEnvironment)
+{
+    base.StartMod(modEnvironment);
+    ModdableTimberbornRegistry.Instance.UseMechanicalSystem();
+}
 ```
 
 Source: [`ModdableMechanicalSystemConfig.cs`](../../ModdableTimberborn/MechanicalSystem/ModdableMechanicalSystemConfig.cs)

--- a/Docs/ModdableTimberborn/README.MD
+++ b/Docs/ModdableTimberborn/README.MD
@@ -10,29 +10,58 @@ Each subsystem is **opt-in**: you enable only the ones you use. See [the Demo pr
 
 Add ModdableTimberborn as a dependency in your mod's `manifest.json` (see the demo's [`manifest.json`](../../ModdableTimberbornDemo/manifest.json)) and reference the assembly from your `.csproj`. Also include ModdableTimberborn's own transitive requirements — `Harmony` and `TimberUi` — in your `RequiredMods` list.
 
-### 2. Enable the subsystems you need
+### 2. Create your mod's configuration
 
-Everything is registered through the singleton `ModdableTimberbornRegistry.Instance`, from your `IModStarter`:
+Your mod's entry point is a class that derives from **`BaseModdableTimberbornConfiguration`** — or **`BaseModdableTimberbornConfigurationWithHarmony`** if your mod also applies Harmony patches. This class *is* your `IModStarter`: it registers itself with `ModdableTimberbornRegistry` automatically, so you don't write a separate starter. Implement `AvailableContexts` (the Bindito context(s) your `Configure` runs in) and `Configure`:
 
 ```cs
-public class MStarter : IModStarter
+public class MyModConfig : BaseModdableTimberbornConfiguration
 {
-    void IModStarter.StartMod(IModEnvironment modEnvironment)
-    {
-        ModdableTimberbornRegistry.Instance
-            // Turn on the built-in subsystems you use:
-            .UseBuildingSettings()
-            .UseEntityTracker()
-            .UseGameStats()
+    // Which Bindito context(s) Configure runs in. This is a [Flags] value —
+    // combine them, e.g. ConfigurationContext.Game | ConfigurationContext.MapEditor.
+    public override ConfigurationContext AvailableContexts { get; } = ConfigurationContext.Game;
 
-            // Register your own configurators:
-            .AddConfigurator<MyGameConfig>()
+    public override void Configure(Configurator configurator, ConfigurationContext context)
+    {
+        configurator
+            .BindFragment<MyEntityPanelFragment>()
+            .BindTemplateModule(h => h
+                .AddDecorator<Enterable, MyBuffComponent>()
+            )
         ;
     }
 }
 ```
 
-The `Use…()` calls turn on a built-in subsystem (they're chainable and idempotent). `AddConfigurator<T>()` registers *your* code; `T` must have a parameterless constructor (`where T : IModdableTimberbornRegistryConfig, new()`). The full set of enablers:
+`Configure` runs once per matching context, using the standard Timberborn/`Configurator` API for your bindings.
+
+> Prefer the base class over hand-rolling an `IModStarter` plus a plain `IModdableTimberbornRegistryConfig`. (Registering a plain config manually via `ModdableTimberbornRegistry.Instance.AddConfigurator<T>()` still works, but the base class is the supported pattern — and is required for the `IWithDIConfig` shortcut below.)
+
+### 3. Enable the subsystems you need
+
+Each built-in subsystem is **opt-in** — turn on only the ones you use:
+
+- **Spec & template modifiers:** implement the `IWithDIConfig` marker interface on your config class. The base class detects it and enables the subsystem for you — nothing else needed:
+
+  ```cs
+  public class MyModConfig : BaseModdableTimberbornConfiguration, IWithDIConfig { /* ... */ }
+  ```
+
+- **Every other subsystem:** override `StartMod`, call `base.StartMod(...)` first, then chain the `Use…()` enablers on the registry (they're chainable and idempotent):
+
+  ```cs
+  public override void StartMod(IModEnvironment modEnvironment)
+  {
+      base.StartMod(modEnvironment);   // registers this config
+
+      ModdableTimberbornRegistry.Instance
+          .UseBuildingSettings()
+          .UseEntityTracker()
+          .UseGameStats();
+  }
+  ```
+
+The available enablers:
 
 | Enabler | Subsystem | Guide |
 |---|---|---|
@@ -44,30 +73,7 @@ The `Use…()` calls turn on a built-in subsystem (they're chainable and idempot
 | `UseMechanicalSystem()` | Runtime-moddable power input/output | [Mechanical System](./MechanicalSystem.MD) |
 | `UseSoakEffect()` | Per-character water-submersion ticks | [Effect Components](./EffectComponents.MD) |
 | `UseAreaApis()` | Spatial zone (area) tracking | [Areas](./Areas.MD) |
-| `IWithDIConfig` (on a `BaseModdableTimberbornConfiguration` subclass) | Spec & template (prefab) modifiers — auto-activates when a config deriving from `BaseModdableTimberbornConfiguration` implements `IWithDIConfig` (see note below). (`UseDependencyInjection()` still works but is `[Obsolete]`.) | [Spec & Template Modifiers](./SpecAndTemplateModifiers.MD) |
-
-### 3. Write a configurator
-
-Your configurator implements `IModdableTimberbornRegistryConfig`. It's invoked once per Bindito **context** (Bootstrapper, MainMenu, Game, MapEditor) — guard for the context you want and bind your services with the standard Timberborn/`Configurator` API:
-
-```cs
-public class MyGameConfig : IModdableTimberbornRegistryConfig
-{
-    public void Configure(Configurator configurator, ConfigurationContext context)
-    {
-        if (!context.IsGameContext()) { return; }
-
-        configurator
-            .BindFragment<MyEntityPanelFragment>()
-            .BindTemplateModule(h => h
-                .AddDecorator<Enterable, MyBuffComponent>()
-            )
-        ;
-    }
-}
-```
-
-> **Heads-up — `IWithDIConfig` needs the base class.** The plain-interface configurator above is fine for binding, but the `IWithDIConfig` opt-in (for [Spec & Template Modifiers](./SpecAndTemplateModifiers.MD)) is only detected when your config derives from `BaseModdableTimberbornConfiguration`. That base type doubles as your `IModStarter`: it auto-registers itself and, when it implements `IWithDIConfig`, enables the DI subsystem for you — so you don't need the separate `MStarter` from step 2. Adding `IWithDIConfig` to a *plain* `IModdableTimberbornRegistryConfig` (as in the example above) has no effect.
+| `IWithDIConfig` (marker interface) | Spec & template (prefab) modifiers — auto-enabled by the base class. (`UseDependencyInjection()` still works but is `[Obsolete]`.) | [Spec & Template Modifiers](./SpecAndTemplateModifiers.MD) |
 
 ## Subsystem guides
 

--- a/Docs/ModdableTimberborn/README.MD
+++ b/Docs/ModdableTimberborn/README.MD
@@ -1,0 +1,82 @@
+# Moddable Timberborn
+
+**ModdableTimberborn** is a foundation library that other Timberborn mods build on. It wraps common but awkward modding tasks — modifying specs and prefabs at load time, adding persistent per-building settings, tracking entities, attaching runtime buffs, exposing game stats — behind small, stable APIs so your mod never has to depend on game internals directly.
+
+Each subsystem is **opt-in**: you enable only the ones you use. See [the Demo project](../../ModdableTimberbornDemo/) for runnable examples of most features.
+
+## Getting started
+
+### 1. Depend on the mod
+
+Add ModdableTimberborn as a dependency in your mod's `manifest.json` (see the demo's [`manifest.json`](../../ModdableTimberbornDemo/manifest.json)) and reference the assembly from your `.csproj`. Also include ModdableTimberborn's own transitive requirements — `Harmony` and `TimberUi` — in your `RequiredMods` list.
+
+### 2. Enable the subsystems you need
+
+Everything is registered through the singleton `ModdableTimberbornRegistry.Instance`, from your `IModStarter`:
+
+```cs
+public class MStarter : IModStarter
+{
+    void IModStarter.StartMod(IModEnvironment modEnvironment)
+    {
+        ModdableTimberbornRegistry.Instance
+            // Turn on the built-in subsystems you use:
+            .UseBuildingSettings()
+            .UseEntityTracker()
+            .UseGameStats()
+
+            // Register your own configurators:
+            .AddConfigurator<MyGameConfig>()
+        ;
+    }
+}
+```
+
+The `Use…()` calls turn on a built-in subsystem (they're chainable and idempotent). `AddConfigurator<T>()` registers *your* code; `T` must have a parameterless constructor (`where T : IModdableTimberbornRegistryConfig, new()`). The full set of enablers:
+
+| Enabler | Subsystem | Guide |
+|---|---|---|
+| `UseBuildingSettings()` | Persistent per-building settings | [Building Settings](./BuildingSettings.MD) |
+| `UseEntityTracker()` | Live typed sets of characters/workplaces | [Entity Tracking & Stats](./EntityTrackingAndStats.MD) |
+| `UseUpdatableEntityStats()` | Observable per-entity UI stats | [Entity Tracking & Stats](./EntityTrackingAndStats.MD) |
+| `UseGameStats()` | String-keyed global game stats | [Game Stats](./GameStats.MD) |
+| `UseBonusTracker()` / `UsePersistentBonusTracker()` | Named bonus-multiplier groups on entities | [Bonus System](./BonusSystem.MD) |
+| `UseMechanicalSystem()` | Runtime-moddable power input/output | [Mechanical System](./MechanicalSystem.MD) |
+| `UseSoakEffect()` | Per-character water-submersion ticks | [Effect Components](./EffectComponents.MD) |
+| `UseAreaApis()` | Spatial zone (area) tracking | [Areas](./Areas.MD) |
+| `IWithDIConfig` (on a `BaseModdableTimberbornConfiguration` subclass) | Spec & template (prefab) modifiers — auto-activates when a config deriving from `BaseModdableTimberbornConfiguration` implements `IWithDIConfig` (see note below). (`UseDependencyInjection()` still works but is `[Obsolete]`.) | [Spec & Template Modifiers](./SpecAndTemplateModifiers.MD) |
+
+### 3. Write a configurator
+
+Your configurator implements `IModdableTimberbornRegistryConfig`. It's invoked once per Bindito **context** (Bootstrapper, MainMenu, Game, MapEditor) — guard for the context you want and bind your services with the standard Timberborn/`Configurator` API:
+
+```cs
+public class MyGameConfig : IModdableTimberbornRegistryConfig
+{
+    public void Configure(Configurator configurator, ConfigurationContext context)
+    {
+        if (!context.IsGameContext()) { return; }
+
+        configurator
+            .BindFragment<MyEntityPanelFragment>()
+            .BindTemplateModule(h => h
+                .AddDecorator<Enterable, MyBuffComponent>()
+            )
+        ;
+    }
+}
+```
+
+> **Heads-up — `IWithDIConfig` needs the base class.** The plain-interface configurator above is fine for binding, but the `IWithDIConfig` opt-in (for [Spec & Template Modifiers](./SpecAndTemplateModifiers.MD)) is only detected when your config derives from `BaseModdableTimberbornConfiguration`. That base type doubles as your `IModStarter`: it auto-registers itself and, when it implements `IWithDIConfig`, enables the DI subsystem for you — so you don't need the separate `MStarter` from step 2. Adding `IWithDIConfig` to a *plain* `IModdableTimberbornRegistryConfig` (as in the example above) has no effect.
+
+## Subsystem guides
+
+- [Building Settings](./BuildingSettings.MD) — add persistent, copy/paste-able settings to buildings.
+- [Entity Tracking & Stats](./EntityTrackingAndStats.MD) — query live sets of characters/workplaces and expose observable stats to the UI.
+- [Bonus System](./BonusSystem.MD) — attach, replace, and persist named groups of bonus multipliers.
+- [Game Stats](./GameStats.MD) — read (and provide) string-keyed global statistics.
+- [Mechanical System](./MechanicalSystem.MD) — modify a building's nominal power at runtime.
+- [Spec & Template Modifiers](./SpecAndTemplateModifiers.MD) — rewrite component specs and prefab templates as the game loads them.
+- [Effect Components](./EffectComponents.MD) — togglable buffs applied while a beaver enters a building, works a job, or is soaked.
+- [Areas](./Areas.MD) — track which characters are inside user-defined zones.
+- [Utilities](./Utilities.MD) — JSON serialization, optional-mod loading, weather compatibility, and assorted services.

--- a/Docs/ModdableTimberborn/SpecAndTemplateModifiers.MD
+++ b/Docs/ModdableTimberborn/SpecAndTemplateModifiers.MD
@@ -1,0 +1,307 @@
+# Spec & Template Modifiers
+
+This subsystem lets you rewrite Timberborn's component-spec blueprints and prefab template blueprints immediately after the game loads them — without writing Harmony patches yourself. Two Harmony postfixes (one on `SpecService.Load`, one on `TemplateCollectionService.Load`) fire a coordinated runner chain that calls your registered services in declaration order.
+
+## Opt in
+
+Add `IWithDIConfig` to your configuration class. `BaseModdableTimberbornConfiguration.StartMod` detects the interface and activates the subsystem automatically:
+
+```cs
+public class MConfigs : BaseModdableTimberbornConfigurationWithHarmony, IWithDIConfig
+{
+    public override ConfigurationContext AvailableContexts { get; }
+        = ConfigurationContext.Game;
+
+    public override void Configure(Configurator configurator, ConfigurationContext context)
+    {
+        if (!context.IsGameContext()) { return; }
+
+        configurator
+            .BindSpecModifier<MyGoodSpecModifier>()
+            .BindTemplateModifier<MyBuildingTemplateModifier>()
+        ;
+    }
+}
+```
+
+The older `ModdableTimberbornRegistry.Instance.UseDependencyInjection()` call still works but is `[Obsolete]`; prefer `IWithDIConfig`.
+
+Source: [`ModdableDependencyInjectionConfig.cs`](../../ModdableTimberborn/DependencyInjection/ModdableDependencyInjectionConfig.cs), [`IModdableTimberbornRegistryConfig.cs`](../../ModdableTimberborn/Registry/IModdableTimberbornRegistryConfig.cs), [`BaseModdableTimberbornConfiguration.cs`](../../ModdableTimberborn/Registry/BaseModdableTimberbornConfiguration.cs)
+
+---
+
+## Spec modifiers
+
+Spec modifiers run **after `SpecService.Load`**. The game has already deserialized all blueprint JSON into in-memory `ComponentSpec` records; your modifier receives a batch of those records and returns a (possibly different) batch. The framework writes the result back into `SpecService._cachedBlueprintsBySpecs` so the rest of the game sees the changes.
+
+### When they run
+
+A Harmony postfix on `SpecService.Load` fires `SpecServiceRunner.OnSpecLoaded`, which calls every registered `ISpecServiceTailRunner` in sequence. The built-in tail runner `SpecModifierService` groups all `ISpecModifier`s by their target `ComponentSpec` type and dispatches them in `Order` order.
+
+If your service implements `ISpecServiceFrontRunner` (which extends `ILoadableSingleton`), its `Load()` is called **before** `SpecService.Load` — useful for reading config files or caching data that the modifier will need. A plain `ISpecModifier` registered via `BindSpecModifier` carries no such timing guarantee.
+
+### Base classes
+
+Three entry points exist, from lowest- to highest-level:
+
+| Class | Use when |
+|---|---|
+| `ISpecModifier` | Full control; you receive and return `IEnumerable<EditableBlueprint>`. |
+| `BaseBlueprintModifier<T>` | Sets `Type` for you; you still work with `EditableBlueprint`. |
+| `BaseSpecModifier<T>` | Each blueprint has exactly one spec of type `T`; you receive and return `IEnumerable<NamedSpec<T>>`. **Warning:** rebuilds each blueprint from a single spec, so all sibling specs and child blueprints are silently dropped. Only safe when each blueprint has exactly one spec of type `T` and no children need preserving. For multi-spec or children cases use `BaseBlueprintModifier<T>` instead (see [`FactionSpecModifier.cs`](../../ConfigurableTubeZipLine/Services/FactionSpecModifier.cs)). |
+| `BaseSpecTransformer<T>` | You transform one `T` at a time; return the modified spec or `null` to leave it unchanged. |
+
+`NamedSpec<T>` is a `readonly record struct` pairing a blueprint name (`string Name`) with a typed spec (`T Spec`).
+
+Source: [`SpecInterfaces.cs`](../../ModdableTimberborn/DependencyInjection/Specs/SpecInterfaces.cs), [`BaseSpecModifier.cs`](../../ModdableTimberborn/DependencyInjection/Specs/BaseSpecModifier.cs), [`BaseSpecTransformer.cs`](../../ModdableTimberborn/DependencyInjection/Specs/BaseSpecTransformer.cs)
+
+### Example — modify existing specs with `BaseSpecModifier<T>`
+
+Append a cross-faction building path to every `TemplateCollectionSpec` entry:
+
+```cs
+// Add a Folktails building to every IronTeeth template collection spec.
+public class FactionSpecModifier : BaseSpecModifier<TemplateCollectionSpec>
+{
+    protected override IEnumerable<NamedSpec<TemplateCollectionSpec>> Modify(
+        IEnumerable<NamedSpec<TemplateCollectionSpec>> specs)
+    {
+        foreach (var s in specs)
+            yield return s; // pass existing specs through unchanged
+
+        // Inject an entirely new spec entry.
+        yield return new("TemplateCollection.Buildings.IronTeeth", new()
+        {
+            CollectionId = "Buildings.IronTeeth",
+            Blueprints = [ /* AssetRef<BlueprintAsset> items */ ],
+        });
+    }
+}
+```
+
+Register it:
+
+```cs
+configurator.BindSpecModifier<FactionSpecModifier>();
+```
+
+Real-world example: [`TemplateCollectionSpecModifier.cs`](../../ConfigurableTubeZipLine/Services/TemplateCollectionSpecModifier.cs)
+
+### Example — transform specs in place with `BaseSpecTransformer<T>`
+
+Change one property on every matching spec without touching blueprint structure:
+
+```cs
+public class GoodSpecModifier(TopBarConfigProvider provider) : BaseSpecTransformer<GoodSpec>
+{
+    public override GoodSpec? Transform(GoodSpec spec)
+    {
+        // Return null to leave this spec unchanged.
+        var compiled = provider.CompileGoodSpecs();
+        if (!compiled.TryGetValue(spec.Id, out var item)) { return null; }
+
+        return spec with
+        {
+            GoodGroupId = item.GroupId,
+            GoodOrder   = item.Order,
+        };
+    }
+}
+```
+
+For reference: [`GoodSpecModifier.cs`](../../ConfigurableTopBar/Services/GoodSpecModifier.cs) uses this pattern, though it is bound as a plain singleton and invoked manually rather than via `BindSpecModifier`.
+
+### Ordering
+
+Both `ISpecModifier.Order` (default `0`) and `ISpecModifier.ShouldRun` (default `true`) are interface default members — override them when needed:
+
+```cs
+public class MyModifier : BaseSpecModifier<GoodSpec>
+{
+    public override int Order => 10; // run after order-0 modifiers
+    public override bool ShouldRun => MSettings.Enabled;
+
+    protected override IEnumerable<NamedSpec<GoodSpec>> Modify(
+        IEnumerable<NamedSpec<GoodSpec>> specs)
+    { /* ... */ }
+}
+```
+
+### Low-level tail runner
+
+For full access to `SpecService` — rather than a single spec type — implement `ISpecServiceTailRunner` directly:
+
+```cs
+public class MySpecTailRunner : ISpecServiceTailRunner
+{
+    public void Run(SpecService specService)
+    {
+        // Inspect or mutate specService as needed.
+    }
+}
+```
+
+Register with:
+
+```cs
+configurator.BindSpecTailRunner<MySpecTailRunner>();
+```
+
+Source: [`SpecServiceRunner.cs`](../../ModdableTimberborn/DependencyInjection/Specs/SpecServiceRunner.cs), [`SpecModifierService.cs`](../../ModdableTimberborn/DependencyInjection/Specs/SpecModifierService.cs)
+
+---
+
+## Template modifiers
+
+Template modifiers run **after `TemplateCollectionService.Load`** (at `HarmonyPriority.First`, so before any other mod's postfix on the same method). The game has already loaded all prefab template blueprints; your modifier receives each one as an `EditableBlueprint` and can replace component specs inside it. The framework writes changes back and updates `BlueprintSourceService` so Timberborn's provenance tracking stays consistent.
+
+### When they run
+
+A Harmony postfix on `TemplateCollectionService.Load` fires `TemplateCollectionTailRunnerService.Run`, which calls every registered `ITemplateCollectionServiceTailRunner` in `Order` sequence. The built-in runner `TemplateModifierTailRunner` iterates all templates, calls each `ITemplateModifier.ShouldModify` as a gate, and if it returns `true` calls `Modify`.
+
+### The `ITemplateModifier` interface
+
+```cs
+public interface ITemplateModifier
+{
+    int Order => 0;
+
+    bool ShouldModify(string blueprintName, string templateName,
+                      TemplateSpec originalTemplateSpec);
+
+    EditableBlueprint? Modify(EditableBlueprint template,
+                              TemplateSpec originalTemplateSpec,
+                              Blueprint original);
+}
+```
+
+- `ShouldModify` is called for every template; return `false` to skip it cheaply.
+- `Modify` receives the working `EditableBlueprint` (may have been modified by an earlier modifier with lower `Order`), the original `TemplateSpec`, and the original unmodified `Blueprint`. Return `null` to leave the template unchanged; return the (mutated) `EditableBlueprint` to apply the change.
+
+Source: [`ITemplateModifier.cs`](../../ModdableTimberborn/DependencyInjection/TemplateCollection/ITemplateModifier.cs), [`TemplateModifierTailRunner.cs`](../../ModdableTimberborn/DependencyInjection/TemplateCollection/TemplateModifierTailRunner.cs)
+
+### Example — modify a component spec inside a prefab template
+
+Halve the max distance and max connections on every zipline tower template:
+
+```cs
+public class ZiplineTemplateModifier : ITemplateModifier
+{
+    public bool ShouldModify(string blueprintName, string templateName,
+                             TemplateSpec originalTemplateSpec)
+        => originalTemplateSpec.IsZipline(); // cheap spec-based gate
+
+    public EditableBlueprint? Modify(EditableBlueprint template,
+                                     TemplateSpec originalTemplateSpec,
+                                     Blueprint original)
+    {
+        for (int i = 0; i < template.Specs.Count; i++)
+        {
+            if (template.Specs[i] is ZiplineTowerSpec tower)
+            {
+                template.Specs[i] = tower with
+                {
+                    MaxConnections = MSettings.ZiplineMaxConnection,
+                    MaxDistance    = MSettings.ZiplineMaxDistance,
+                };
+            }
+        }
+
+        return template; // returning non-null marks the template as changed
+    }
+}
+```
+
+Register it:
+
+```cs
+configurator.BindTemplateModifier<ZiplineTemplateModifier>();
+```
+
+Real-world example: [`ZiplineTemplateModifier.cs`](../../ConfigurableTubeZipLine/Services/ZiplineTemplateModifier.cs)
+
+### Low-level tail runner
+
+For direct access to `TemplateCollectionService` implement `ITemplateCollectionServiceTailRunner`:
+
+```cs
+public class MyTemplateTailRunner : ITemplateCollectionServiceTailRunner
+{
+    public int Order => 5;
+
+    public void Run(TemplateCollectionService templateCollectionService)
+    {
+        // Read or rewrite templateCollectionService.AllTemplates as needed.
+    }
+}
+```
+
+Register with:
+
+```cs
+configurator.BindTemplateTailRunner<MyTemplateTailRunner>();
+```
+
+If the runner also implements `ILoadableSingleton`, its `Load()` runs **before** `TemplateCollectionService.Load`.
+
+Source: [`ITemplateCollectionServiceTailRunner.cs`](../../ModdableTimberborn/DependencyInjection/TemplateCollection/ITemplateCollectionServiceTailRunner.cs), [`TemplateCollectionTailRunnerService.cs`](../../ModdableTimberborn/DependencyInjection/TemplateCollection/TemplateCollectionTailRunnerService.cs)
+
+---
+
+## `EditableBlueprint`
+
+Both pipelines pass data as `EditableBlueprint`, a mutable wrapper around Timberborn's immutable `Blueprint`:
+
+| Member | Type | Purpose |
+|---|---|---|
+| `Name` | `string` | Blueprint name (e.g. `"TemplateCollection.Buildings.Folktails"`). |
+| `Specs` | `List<ComponentSpec>` | All component specs on this blueprint. |
+| `Children` | `List<EditableBlueprint>` | Child blueprints, if any. |
+| `GetSpec<T>()` | `T` | Returns the first spec of type `T`; throws if absent. |
+| `TransformSpec<T>(Func<T, T?>)` | `void` | Replaces every spec of type `T` in place. |
+| `ToBlueprint()` | `Blueprint` | Converts back to an immutable `Blueprint`. |
+
+Source: [`EditableBlueprint.cs`](../../ModdableTimberborn/DependencyInjection/EditableBlueprint.cs)
+
+---
+
+## `AssetRefService`
+
+When a spec modifier needs to inject asset references (e.g. adding blueprint paths to a `TemplateCollectionSpec`), inject `AssetRefService` — a bootstrapper-context singleton that wraps `IAssetLoader`:
+
+```cs
+public class MySpecModifier(AssetRefService assetRefService) : BaseSpecModifier<TemplateCollectionSpec>
+{
+    protected override IEnumerable<NamedSpec<TemplateCollectionSpec>> Modify(
+        IEnumerable<NamedSpec<TemplateCollectionSpec>> specs)
+    {
+        foreach (var s in specs)
+            yield return s;
+
+        yield return new("TemplateCollection.Buildings.Folktails", new()
+        {
+            CollectionId = "Buildings.Folktails",
+            Blueprints = [..assetRefService.CreateBlueprintAssetRefs([
+                "Buildings/Paths/MyBuilding/MyBuilding.Folktails.blueprint",
+            ])],
+        });
+    }
+}
+```
+
+Source: [`AssetRefService.cs`](../../ModdableTimberborn/DependencyInjection/AssetRefService.cs)
+
+---
+
+## Registration quick-reference
+
+All helpers are extension methods on `Configurator` from [`ConfigurationExtensions.cs`](../../ModdableTimberborn/Helpers/ConfigurationExtensions.cs):
+
+| Method | Registers as |
+|---|---|
+| `configurator.BindSpecModifier<T>()` | `ISpecModifier` (multi-bound singleton) |
+| `configurator.BindSpecTailRunner<T>()` | `ISpecServiceTailRunner` (multi-bound singleton) |
+| `configurator.BindTemplateModifier<T>()` | `ITemplateModifier` (multi-bound singleton) |
+| `configurator.BindTemplateTailRunner<T>()` | `ITemplateCollectionServiceTailRunner` (multi-bound singleton) |
+
+Pass `alsoBindSelf: true` to any of these if you also need the concrete type injected elsewhere. All bindings are singletons; the game context guard in your `Configure` method determines when they are active.

--- a/Docs/ModdableTimberborn/Utilities.MD
+++ b/Docs/ModdableTimberborn/Utilities.MD
@@ -1,0 +1,280 @@
+# Utilities
+
+ModdableTimberborn ships several small, self-contained subsystems that are useful across many mod types. This page covers four of them: JSON serialization helpers for Timberborn's property-bag type, optional-mod DLL loading, a weather-API compatibility layer, and a pair of injectable services for day-scheduled actions and coordinated destruction.
+
+---
+
+## JSON Serialization
+
+Timberborn's [`SerializedObject`](../../ModdableTimberborn/SerializationSystem/ModdableTimberbornSerializedObjectExtensions.cs) is a structured property bag that standard Newtonsoft.Json converters cannot handle out of the box. The serialization subsystem bridges that gap with two types.
+
+**[`SerializedObjectJsonConverter`](../../ModdableTimberborn/SerializationSystem/SerializedObjectJsonConverter.cs)** is a singleton `JsonConverter<SerializedObject>` that recursively serializes and deserializes `SerializedObject` trees to and from JSON. It supports nested objects, arrays, and the primitive types `int`, `float`, `bool`, `string`, and `null`. Unsupported token types throw `JsonSerializationException` — there is no silent fallback.
+
+**[`ModdableTimberbornSerializationExtensions`](../../ModdableTimberborn/SerializationSystem/ModdableTimberbornSerializedObjectExtensions.cs)** (namespace `Timberborn.SerializationSystem`) exposes three convenience helpers that pre-wire the converter:
+
+| Member | Kind | Description |
+|---|---|---|
+| `DeserializeSerializedObject(string json)` | static method | Deserializes a JSON string into a `SerializedObject`. |
+| `obj.SerializeToJson()` | extension | Serializes a `SerializedObject` to a JSON string. |
+| `obj.DeserializeTo<T>()` | extension | Round-trips a `SerializedObject` through JSON into a strongly-typed `T`. |
+
+Because the extensions live in the `Timberborn.SerializationSystem` namespace — the same namespace as `SerializedObject` itself — no additional `using` directive is needed at the call site.
+
+### Example
+
+```cs
+// Serialize a SerializedObject received from Timberborn's pipeline
+string json = mySerializedObject.SerializeToJson();
+
+// Reconstruct from a stored string
+SerializedObject? restored = ModdableTimberbornSerializationExtensions
+    .DeserializeSerializedObject(json);
+
+// Map directly into a typed record
+MyBuildingData data = mySerializedObject.DeserializeTo<MyBuildingData>();
+```
+
+> `DeserializeTo<T>()` performs a serialize-then-deserialize round-trip internally. Custom `JsonSerializerSettings` passed to it apply only to the final deserialization step, not to the `SerializedObject` read — the converter is always active on the first pass. **Caution:** caller-supplied settings do not include `SerializedObjectJsonConverter`, so any nested `SerializedObject` fields inside `T` will not receive converter handling during that deserialization pass.
+
+---
+
+## Optional Mods
+
+Sometimes a mod provides extra integration with a second mod, but should not hard-reference that second mod's assembly — doing so would cause load failures for users who don't have it installed. The optional-mod system solves this by loading additional DLLs at runtime only when their target companion mod is enabled.
+
+### File naming convention
+
+Place the integration DLL in your mod's directory (any subfolder is fine) and name it:
+
+```
+<anything>.dll.<targetModId>.optional
+```
+
+Where `<targetModId>` is the exact mod ID of the companion mod that must be enabled for this DLL to load. For example, if your mod's base name is `MyMod` and the companion mod has ID `SomeCoolMod`:
+
+```
+MyMod.dll.SomeCoolMod.optional
+```
+
+At startup, `OptionalModsLoader` scans every enabled mod's directory tree for files matching `*.dll.*.optional`. For each file it extracts the `<targetModId>` segment and checks whether that mod is currently enabled. If it is, the DLL bytes are read from disk and loaded via `Assembly.Load(bytes)`; if not, the file is verbose-logged then skipped.
+
+### Implementing the entry point
+
+The loaded DLL must contain at least one concrete `IModStarter` implementation. `OptionalModsLoader` reflects over all exported types, finds concrete `IModStarter` classes, and calls `StartMod` on each one — exactly the same lifecycle as a regular Timberborn mod.
+
+```cs
+// Inside your optional DLL:
+public class MySomeCoolModIntegrationStarter : IModStarter
+{
+    public void StartMod(IModEnvironment modEnvironment)
+    {
+        // Register Bindito configurators, apply Harmony patches, etc.
+        new Harmony("MyMod.SomeCoolMod").PatchAll();
+    }
+}
+```
+
+No changes to the host mod's configurator or Harmony setup are required — `OptionalModsLoader` handles discovery automatically.
+
+> The `.optional` extension is part of the full file name, not a separate file extension known to the OS. Ensure your build output preserves the full name; a post-build copy step is the most reliable approach.
+
+---
+
+## Weather Compatibility
+
+Timberborn's internal weather API (`WeatherService`, `HazardousWeatherService`, etc.) may change between game updates. The `CompatWeatherService` subsystem provides a stable abstraction so mods never depend on those types directly.
+
+### How it works
+
+[`CompatWeatherService`](../../ModdableTimberborn/CompatWeatherService/CompatWeatherService.cs) is a `[BindSingleton]` that collects all registered [`ICompatWeatherServiceProvider`](../../ModdableTimberborn/CompatWeatherService/ICompatWeatherServiceProvider.cs) implementations at construction time, picks the one with the highest `Priority`, and exposes it as the `Provider` property. A missing provider causes a hard throw at startup.
+
+[`DefaultCompatWeatherServiceProvider`](../../ModdableTimberborn/CompatWeatherService/DefaultCompatWeatherServiceProvider.cs) wraps the vanilla game services and registers itself with priority `-1`. Any mod-supplied provider with priority `0` or above takes over entirely — there is no fallback chaining.
+
+### `ICompatWeatherServiceProvider` at a glance
+
+```cs
+public interface ICompatWeatherServiceProvider
+{
+    IReadOnlyList<CompatWeatherType> WeatherTypes { get; }
+    int Priority { get; }
+    int ApproachingNotificationDays { get; }
+    string? CurrentCycleHazardousId { get; }
+    bool IsHazardous { get; }
+    bool IsNextDayHazardous { get; }
+
+    CompatWeatherCycle GetCurrentCycle();
+    CompatWeatherCycleStage GetCurrentCycleStage();
+    CompatWeatherCycleStage? GetCurrentCycleBenignStage();
+    CompatWeatherCycleStage? GetCurrentCycleHazardousStage();
+    CompatNextWeatherCycleStage GetNextCycleStage();
+    CompatWeatherWarning GetWarningStatus();
+}
+```
+
+The built-in weather IDs are available as constants on `CompatWeatherService`: `TemperateId`, `DroughtId`, `BadtideId`.
+
+### Consuming the service
+
+Inject `CompatWeatherService` and read from `Provider`:
+
+```cs
+[BindSingleton]
+public class MyWeatherReactor(CompatWeatherService compatWeather) : ILoadableSingleton
+{
+    public void Load()
+    {
+        var provider = compatWeather.Provider;
+
+        if (provider.IsHazardous)
+        {
+            string weatherId = provider.CurrentCycleHazardousId!;
+            // React to active hazard...
+        }
+
+        CompatWeatherWarning warning = provider.GetWarningStatus();
+        if (warning.Stage == CompatWeatherWarningStage.Showing)
+        {
+            float daysLeft = warning.DaysToHazardous!.Value;
+            // Show approaching-hazard UI...
+        }
+    }
+}
+```
+
+### Supplying a custom provider
+
+If your mod introduces an entirely different weather system, register an `ICompatWeatherServiceProvider` with a priority above `-1`:
+
+```cs
+[MultiBind(typeof(ICompatWeatherServiceProvider))]
+public class MyWeatherProvider : ICompatWeatherServiceProvider
+{
+    public int Priority => 10; // beats the default
+    // ... implement remaining members
+}
+```
+
+All existing consumers automatically use your provider without any changes on their end.
+
+---
+
+## Services
+
+### DayTimerService
+
+[`DayTimerService`](../../ModdableTimberborn/Services/DayTimerService.cs) is a `[BindSingleton]` that lets you schedule an `Action` to fire at a precise in-game hour offset after each day starts. It listens on the `EventBus` for `CycleDayStartedEvent` and uses `ITimeTriggerFactory` to fire each bucket at the correct fractional-day offset — callbacks do not run at midnight unless you ask for delay `0`.
+
+**Public API:**
+
+```cs
+// Fire every day, 0.25 in-game hours after midnight (default delay)
+DayTimerReference Register(Action action, float delayed = 0.25f)
+
+// Fire once on the next day, then auto-remove
+DayTimerReference RegisterOnce(Action action, float delayed = 0.25f)
+
+// Overload with explicit repeat flag
+DayTimerReference Register(Action action, float delayed, bool repeat)
+
+// Cancel a previously registered timer
+void Unregister(DayTimerReference r)
+```
+
+`DayTimerReference` is a plain `record(float DelayedHours, Action Action, bool Repeat)`. Hold on to the returned reference and call `Unregister` when your component is torn down.
+
+**Example:**
+
+```cs
+[BindSingleton]
+public class MyDailyTask(DayTimerService dayTimer) : ILoadableSingleton, IUnloadableSingleton
+{
+    DayTimerReference _timer = null!;
+
+    public void Load()
+    {
+        // Run every in-game day, 6 hours after midnight
+        _timer = dayTimer.Register(OnEachDay, delayed: 6f);
+    }
+
+    public void Unload()
+    {
+        dayTimer.Unregister(_timer);
+    }
+
+    void OnEachDay()
+    {
+        // ...
+    }
+}
+```
+
+---
+
+### DestructionService
+
+[`DestructionService`](../../ModdableTimberborn/Services/DestructionService.cs) is a `[BindSingleton]` (excluded from the menu scene via `BindAttributeContext.NonMenu`) that manages the full lifecycle of block-object and terrain destruction: querying the affected set, highlighting it in the UI, and executing deletion.
+
+The API follows a three-step pipeline:
+
+| Step | Method | Description |
+|---|---|---|
+| Query | `QueryDestructingEntities(IEnumerable<Vector3Int> terrains)` | Returns a `DestroyingEntities` snapshot of all block objects and terrain tiles that would be removed, including physics-dependent objects above the given tiles. |
+| Query | `QueryDestructingEntities(IEnumerable<BlockObject> blockObjects)` | Same, but starting from block objects instead of terrain. |
+| Highlight | `HighlightDestructionEntities(DestroyingEntities entities)` | Highlights the set in the game's negative (red) color. |
+| Highlight | `HighlightDestructionEntities(DestroyingEntities entities, Color color)` | Highlights in a specific color. |
+| Unhighlight | `UnhighlightDestructionEntities()` | Removes all destruction highlights (call on cancel). |
+| Destroy | `DestroyEntities(DestroyingEntities entities)` | Deletes all block objects via `EntityService` and all terrain tiles via `TerrainDestroyer`. |
+
+`DestroyingEntities` is a `readonly record struct` carrying `ImmutableArray<BlockObject> BlockObjects` and `ImmutableArray<Vector3Int> Terrains`.
+
+**Example:**
+
+```cs
+// In a tool that destroys whatever the cursor is over:
+var terrains = GetSelectedTerrainCoords(); // your logic
+
+DestroyingEntities affected = destructionService.QueryDestructingEntities(terrains);
+destructionService.HighlightDestructionEntities(affected);
+
+// On confirm:
+destructionService.UnhighlightDestructionEntities();
+destructionService.DestroyEntities(affected);
+
+// On cancel:
+destructionService.UnhighlightDestructionEntities();
+```
+
+> Do not reuse a `DestroyingEntities` value after the selection changes — the `ImmutableArray` snapshots it holds are stable and safe to keep across frames, but they reflect the selection at query time. Start a fresh query whenever the selection changes to get an up-to-date set.
+
+---
+
+### ContainerRetriever
+
+[`ContainerRetriever`](../../ModdableTimberborn/Services/ContainerRetriever.cs) exposes static access to the Bindito `IContainer` for use in static helpers or Harmony patches where constructor injection is not available. It is **not** registered through DI — a Harmony postfix on `ContainerCreator.CreateContainer` constructs it once the container exists (see [`ContainerRetrieverPatches`](../../ModdableTimberborn/Patches/ContainerRetrieverPatches.cs)). It holds a `WeakReference<IContainer>` and exposes the container through static accessors.
+
+**Public surface:**
+
+| Member | Description |
+|---|---|
+| `ContainerRetriever.Instance` | Returns the current retriever, or throws `InvalidOperationException` if the container has been collected. |
+| `ContainerRetriever.InstanceOrNull` | Same, but returns `null` instead of throwing. |
+| `ContainerRetriever.GetInstance<T>()` | Resolves an instance of `T` from the container. |
+| `ContainerRetriever.GetInstance(Type)` | Non-generic overload. |
+| `ContainerRetriever.GetInstances<T>()` | Resolves all bound instances of `T`. |
+| `ContainerRetriever.GetInstances(Type)` | Non-generic overload. |
+
+**Example (Harmony patch context):**
+
+```cs
+[HarmonyPatch(typeof(SomeVanillaClass), nameof(SomeVanillaClass.SomeMethod))]
+static class SomeVanillaPatch
+{
+    static void Postfix()
+    {
+        var myService = ContainerRetriever.GetInstance<MyService>();
+        myService.DoSomething();
+    }
+}
+```
+
+> Prefer constructor injection wherever possible — `ContainerRetriever` is a last resort for code paths the DI container cannot reach.

--- a/Docs/README.MD
+++ b/Docs/README.MD
@@ -2,6 +2,7 @@
 
 Documentations for various Moddable projects.
 
+- [Moddable Timberborn](./ModdableTimberborn#README)
 - [Moddable Tool Groups](./ModdableToolGroups#README)
 - [Moddable Recipes](./ModdableRecipes#README)
 - [Moddable Decal Groups](./ModdableDecalGroups.MD)


### PR DESCRIPTION
Adds task-oriented documentation for the **ModdableTimberborn** library under `Docs/ModdableTimberborn/`, following the existing `Docs/` convention (e.g. ModdableToolGroups / ModdableRecipes).

**Contents**
- `README.MD` — getting started: depending on the mod, enabling subsystems via `ModdableTimberbornRegistry.Instance`, and writing a configurator.
- One page per subsystem: Building Settings, Entity Tracking & Stats, Bonus System, Game Stats, Mechanical System, Spec & Template Modifiers, Effect Components, Areas, and Utilities.
- Linked from the root `Docs/README.MD` index.

Each page is task-oriented (how to *use* the API) with verified type/method names and links into the source and the `ModdableTimberbornDemo` examples.

**Notes for review**
- Examples were verified against the current source, but not yet compiled (no game assemblies in my dev environment) — worth a build pass.
- A few pages reference `ModdableTimberbornDemo` as the canonical example; some demo files may be out of sync with the current API.

This is one of two independent doc PRs — a separate one adds per-folder READMEs, so you can take either or both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)