### PR TITLE
Docs: per-folder READMEs for ModdableTimberborn

### DIFF
--- a/ModdableTimberborn/Areas/README.md
+++ b/ModdableTimberborn/Areas/README.md
@@ -1,0 +1,46 @@
+# Areas
+
+## Purpose
+
+Provides spatial-query APIs for tracking which game entities (characters, block objects) occupy or intersect one or more user-defined rectangular volumes. It exists because Timberborn has no built-in "which characters are inside this zone right now" service; this subsystem fills that gap in a performance-aware way using a 2-D segment grid to prune unnecessary checks.
+
+## Key types
+
+- **`AreaSegmentService`** — Singleton. Partitions the map into 26-tile-wide segments on load. Converts coordinates and `BoundsInt` ranges into segment indices, used by every tracker to skip irrelevant handles.
+- **`AreaTrackerRegistration`** / **`CharacterAreaTrackerRegistration`** / **`BlockObjectAreaTrackerRegistration`** — Plain data bags callers fill in to describe the area(s) they want to watch and the entity filter criteria (character type flags, template names, finished-only, etc.).
+- **`AreaTrackerHandle<T, TRegistration>`** — Abstract base that owns the live `Entities` set, the enter/exit events (`OnEntityEntered`, `OnEntityExited`), and the deferred-mutation collection (`DeferredHashSet`). Subclasses supply `IsEntityInAreas`.
+- **`CharacterAreaTrackerHandle`** — Concrete handle for characters. Filters by `CharacterType` flags and checks `BoundsInt.Contains(cell)`.
+- **`CharacterAreaTrackerService`** — Singleton. Manages all registered `CharacterAreaTrackerHandle` instances. Hooks into `CharacterTracker` for entity lifecycle, and into each `CharacterPositionTracker.OnCellChanged` (only for types that have live handles, lazy subscribe/unsubscribe). Routes cell-change events through segment buckets to notify only relevant handles.
+- **`CharacterPositionTracker`** — `TickableComponent` decorator on `Character`. Each tick, detects world-position change, updates `Cell` (floor-to-int) and `Segment`, fires `OnPositionChanged` / `OnCellChanged` accordingly.
+- **`BlockObjectBound`** — `BaseComponent` decorator on `BlockObject`. Lazily caches the object's `BoundsInt` and segment list; re-computes only when `Coordinates` changes.
+- **`AreaCondition`** — Enum: `Intersects` or `Contains`. Evaluated by extension methods in `AreaExtensions`.
+- **`AreaExtensions`** (in `ModdableTimberborn.Helpers`) — C# 13 `extension` blocks adding `GetBounds()` to `BlockObject`, `Evaluate(BoundsInt, BoundsInt)` to `AreaCondition`, and `Intersects`/`Contains` to `BoundsInt` (Unity's `BoundsInt` lacks these natively).
+- **`SerializableBounds`** / **`SerializableBoundsInts`** — Readonly record structs with implicit casts to/from Unity `Bounds`/`BoundsInt`, wrapping the project's `SerializableFloats`/`SerializableInts` helpers for JSON-safe serialization.
+
+## How it fits together
+
+Opt-in via `ModdableTimberbornRegistry.UseAreaApis()` (idempotent). This registers `AreaSegmentService` and `CharacterAreaTrackerService` as singletons, and attaches `CharacterPositionTracker` and `BlockObjectBound` as decorators on every `Character` and `BlockObject` entity respectively (through Bindito's template-module decorator pattern).
+
+A mod that wants to know which characters are inside a zone calls `CharacterAreaTrackerService.RegisterArea(registration)` at runtime (typically on load or when a building activates), receiving a `CharacterAreaTrackerHandle`. It then subscribes to `handle.OnEntityEntered` / `OnEntityExited`, or polls `handle.Entities`. When done (building destroyed, etc.) it calls `UnregisterArea(handle)`.
+
+On every game tick, `CharacterPositionTracker.Tick()` fires `OnCellChanged` when a character crosses a tile boundary. `CharacterAreaTrackerService` listens only on character types that have at least one registered handle, and uses the old and new segment indices to look up only the small subset of handles that overlap those segments — avoiding O(handles × characters) checks per tick.
+
+`BlockObjectBound` is wired in but a `BlockObjectAreaTrackerHandle`/service is not yet present in this folder — the registration type (`BlockObjectAreaTrackerRegistration`) exists, suggesting it is planned.
+
+## Dependencies & patterns
+
+- **Bindito DI:** `AreaConfig` implements `IModdableTimberbornRegistryConfig` and is registered by the registry. `AreaSegmentService` and `CharacterAreaTrackerService` are singletons bound with `.BindSingleton<>()`. `CharacterPositionTracker` and `BlockObjectBound` are bound as entity decorators via `.BindTemplateModule(h => h.AddDecorator<...>())`.
+- **Timberborn entity systems:** `CharacterTracker` (for entity registration events), `CharacterTrackerComponent` (character identity), `BlockObject` / `MapSize`.
+- **`ILoadableSingleton`:** Both services implement this to perform initialization after the map is fully loaded.
+- **`TickableComponent`:** `CharacterPositionTracker` is a per-tick component; it uses `transform.position` rather than a grid-cell component, so it tracks sub-tile movement too.
+- **`DeferredHashSet<T>`:** Used internally to allow mutation during iteration (avoid modification-during-enumeration bugs in event callbacks).
+- **Unity math types:** `BoundsInt`, `Bounds`, `Vector3`, `Vector3Int`, `RectInt` — extended by `AreaExtensions` to fill gaps in Unity's API.
+- **C# 13 `extension` blocks** in `AreaExtensions.cs` — requires a modern C# language version in the project file.
+
+## Notes / gotchas
+
+- **Segment size is a hardcoded constant** (`AreaSegmentService.SegmentSize = 26`). There is no tuning API.
+- **Z-axis not segmented.** `AreaSegmentService` intentionally only segments X/Y; the comment says Z is "typically small enough." Area containment checks still use all three axes via `BoundsInt`.
+- **`CharacterType.ArrayLength`** is used as an array size, implying `CharacterType` is a flags enum whose values are used directly as array indices — callers must be careful not to pass combined flags as array indices.
+- **`AreaExtensions` lives in the `ModdableTimberborn.Helpers` namespace**, not `ModdableTimberborn.Areas` — a minor namespace inconsistency compared to the rest of the folder.
+- **`UseAreaApis()` calls `UseEntityTracker()` and `TryTrack<>`**, so enabling Areas implicitly enables the entity tracker subsystem.

--- a/ModdableTimberborn/BonusSystem/README.md
+++ b/ModdableTimberborn/BonusSystem/README.md
@@ -1,0 +1,40 @@
+# BonusSystem
+
+## Purpose
+
+Provides a named, keyed layer on top of Timberborn's native `BonusManager`/`BonusSpec` API, letting mod code attach a group of bonus multipliers to an entity under a single string ID and replace or remove them atomically. This avoids the accumulation/leak problem that arises when callers add raw `BonusSpec` entries directly without tracking what they've already applied.
+
+## Key types
+
+- **`BonusTracker`** — Core logic class (not a component). Owns a `Dictionary<string, BonusTrackerItem>` and proxies `BonusManager.AddBonuses` / `RemoveBonuses`. Fires `OnBonusChanged` whenever an entry is added, updated, or removed. Constructed by the component types in `Awake`.
+- **`BonusTrackerItem`** — Immutable `readonly record struct` pairing a string `Id` with a list of `BonusSpec` values. Several convenience constructors accept a raw float, a `BonusType` enum, or a single `BonusSpec`.
+- **`IBonusTrackerComponent`** — Single-property interface (`BonusTracker BonusTracker { get; }`). The extension methods target this interface, so any component that exposes a tracker gets the fluent API automatically.
+- **`BonusTrackerComponent`** — Transient decorator component (no persistence). Implements `IBonusTrackerComponent` + `IAwakableComponent`; creates a `BonusTracker` on `Awake`.
+- **`PersistentBonusTrackerComponent`** — Persistent variant; additionally implements `IPersistentEntity` + `IStartableComponent`. Saves/loads the full `CurrentBonuses` dictionary via Timberborn's entity save system, replaying loaded items in `Start` (after `BonusManager` is ready).
+- **`BonusTrackerItemSerializer`** — Singleton `IValueSerializer<BonusTrackerItem>`; used by `PersistentBonusTrackerComponent` to read/write items as parallel `Id`/`BonusIds`/`Values` lists.
+- **`BonusSystemExtensions`** — Static helper forwarding `AddOrUpdate`, `Remove`, and `CurrentBonuses` directly from any `IBonusTrackerComponent`, removing the need to drill through `.BonusTracker`.
+- **`BonusSystemHelpers`** — String constants for the six standard bonus IDs (`CarryingCapacity`, `CuttingSuccessChance`, `GrowthSpeed`, `LifeExpectancy`, `MovementSpeed`, `WorkingSpeed`).
+- **`BonusSystemConfig`** — `IModdableTimberbornRegistryConfig` configurator; registers whichever decorator component variant(s) are enabled as `BindTemplateModule` decorators on `BonusManager`.
+
+## How it fits together
+
+Mod startup calls `ModdableTimberbornRegistry.Instance.UseBonusTracker()` or `UsePersistentBonusTracker()`. Either call sets a flag on the registry's partial class (defined here) and, on the first call, registers `BonusSystemConfig` as a configurator. At game-scene binding time, `BonusSystemConfig.Configure` decorates every `BonusManager` entity with `BonusTrackerComponent` or `PersistentBonusTrackerComponent` via Bindito's `BindTemplateModule`.
+
+Consumers obtain the component via Timberborn's normal entity-component lookup, cast it (or receive it already typed) as `IBonusTrackerComponent`, and call `AddOrUpdate` / `Remove` (directly or through the extension methods). `BonusTracker` internally calls `BonusManager.RemoveBonuses` for the old item then `AddBonuses` for the new one, keeping the underlying multipliers in sync.
+
+For the persistent variant, loaded bonus data is stashed as a `List<BonusTrackerItem>` during `Load` and replayed in `Start` so that `BonusManager` is guaranteed to be initialized before bonuses are applied. `Save` skips writing entirely when `CurrentBonuses` is empty.
+
+## Dependencies & patterns
+
+- **Timberborn internals:** `BonusManager`, `BonusSpec`, `BonusType` (game's native bonus system); `IPersistentEntity` / `IEntityLoader` / `IEntitySaver` (save/load); `BaseComponent`, `IAwakableComponent`, `IStartableComponent`.
+- **Bindito (DI):** `BindTemplateModule` + `AddDecorator` to inject components onto existing entity templates without patching their prefabs.
+- **Registry pattern:** `ModdableTimberbornRegistry` (partial class, extended here) acts as a global opt-in switch; calling `UseBonusTracker` / `UsePersistentBonusTracker` is the only required configuration step for consumers.
+- **No Harmony patches** in this folder — integration is entirely through Bindito decorators.
+- **Serialization:** Custom `IValueSerializer<BonusTrackerItem>` using Timberborn's `PropertyKey`/`ListKey` API; parallel lists for bonus IDs and multiplier deltas.
+
+## Notes / gotchas
+
+- Only one variant (transient or persistent) should be registered per game context; both flags can technically be set but the guards (`if (!BonusTrackerUsed && !PersistentBonusTrackerUsed)`) only prevent double-registering the configurator, not double-decorating the entity.
+- `AddOrUpdateOrRemove` on `BonusTracker` silently removes an item if all its `MultiplierDelta` values are zero — convenient but can be surprising if callers construct a zero-delta item expecting a no-op add.
+- The `pending` list in `PersistentBonusTrackerComponent` is `null` unless `Load` is called, which is the expected game-save path. Cold-start (new game) never calls `Load`, so `Start` becomes a safe no-op.
+- `BonusTrackerItemSerializer` is a singleton accessed via `Instance`; it is not DI-registered and must be passed explicitly wherever serialization is needed.

--- a/ModdableTimberborn/BuildingSettings/BuiltInSettings/README.md
+++ b/ModdableTimberborn/BuildingSettings/BuiltInSettings/README.md
@@ -1,0 +1,98 @@
+# BuiltInSettings
+
+## Purpose
+
+Contains one concrete `IBuildingSettings` handler for every stock Timberborn `IDuplicable` component type, plus the shared model record types they use. Each handler snapshots a single component to JSON and reapplies it to a target component, with guard logic to skip inapplicable targets. This is the exhaustive "built-in" coverage that ships with ModdableTimberborn.
+
+## Key types
+
+### Shared model primitives (`CommonSettingModels.cs`)
+
+- **`ValueSettingModel<T>`** — single-value wrapper record with implicit conversion to `T`.
+- **`BoolSettingModel`**, **`IntSettingModel`**, **`FloatSettingModel`**, **`StringSettingModel`** — typed specializations; `BoolSettingModel` knows how to call `ILoc.TYesNo`.
+- **`CachableStringSettingModel<T>`** — `StringSettingModel` subclass that lazily resolves a display name and a typed object (e.g., `RecipeSpec`, `GoodSpec`, `PlantableSpec`, `GatherableSpec`) on first access; avoids repeated lookups. Cached fields are `[JsonIgnore]`.
+- **`PrioritySettingModel`** — wraps `Priority` with `ILoc.T` formatting.
+
+### Shared model primitives (`ComparisonSettingsModel.cs`)
+
+- **`ComparisonSettingsModel`** — `(NumericComparisonMode Mode, float Threshold)` record used by all threshold-style sensors.
+
+### Entity-id model (`EntityIdModelBase` — in parent namespace)
+
+Several models inherit `EntityIdModelBase` so that entity-GUID remapping works generically. Examples: `AutomatableSettingsModel`, `RelaySettingsModel`, `MemorySettingsModel`, `TimerSettingsModel`.
+
+### Handler classes (one per component type)
+
+| Handler | Component | Model | Notes |
+|---|---|---|---|
+| `AutomatableSettings` | `Automatable` | `AutomatableSettingsModel` | Entity-id; resolves/sets automator via `EntityRegistry`. |
+| `BuilderPrioritizableSettings` | `BuilderPrioritizable` | `PrioritySettingModel` | Guards on `Enabled` or `BlockObject.IsFinished`. |
+| `ChronometerSettings` | `Chronometer` | `ChronometerSettingsModel` | Calls `UpdateOutputState()` after apply. |
+| `ClutchSettings` | `Clutch` | `ClutchSettingsModel` | Calls `ApplyState()`. |
+| `ContaminationSensorSettings` | `ContaminationSensor` | `ComparisonSettingsModel` | — |
+| `CustomizableIlluminatorSettings` | `CustomizableIlluminator` | `CustomizableIlluminatorSettingsModel` | Accesses private `_customColor` field; serializes color as `SerializableFloats`. |
+| `DecalSupplierSettings` | `DecalSupplier` | `DecalSupplierSettingsModel` | Guards on `Category` match. |
+| `DemolishableSettings` | `Demolishable` | `BoolSettingModel` | Calls `Mark()`/`Unmark()`. |
+| `DepthSensorSettings` | `DepthSensor` | `ComparisonSettingsModel` | Calls `InitializeSensorCoordinates()` before writing threshold. |
+| `DistrictDefaultWorkerTypeSettings` | `DistrictDefaultWorkerType` | `StringSettingModel` | Uses `WorkerTypeHelper` for display. |
+| `FarmHouseSettings` | `FarmHouse` | `BoolSettingModel` | `PlantingPrioritized`. |
+| `FireworkLauncherSettings` | `FireworkLauncher` | `FireworkLauncherSettingsModel` | Falls back to first available firework if stored ID is missing. |
+| `FixedStockpileInventorySetterSettings` | `FixedStockpileInventorySetter` | `FixedStockpileInventorySetterSettingsModel` | Guards on `WhitelistedGoodType` match; accesses private `_stockpile` / `_singleGoodAllower`. |
+| `FlippableDecalSettings` | `FlippableDecal` | `BoolSettingModel` | — |
+| `FloodgateSettings` | `Floodgate` | `FloodgateSettingsModel` | Clamps height; calls `SynchronizeAllNeighbors()`. |
+| `FlowSensorSettings` | `FlowSensor` | `ComparisonSettingsModel` | — |
+| `ForesterSettings` | `Forester` | `BoolSettingModel` | `ReplantDeadTrees`. |
+| `GateSettings` | `Gate` | `ValueSettingModel<GateOpeningMode>` | Accesses private `_gateOpeningMode`. |
+| `GatherablePrioritizerSettings` | `GatherablePrioritizer` | `CachableStringSettingModel<GatherableSpec>` | Uses `TemplateNameMapper` to resolve spec; guards on `SupportsGatherable`. |
+| `HaulPrioritizableSettings` | `HaulPrioritizable` | `BoolSettingModel` | `Prioritized`. |
+| `HttpAdapterSettings` | `HttpAdapter` | `HttpAdapterSettingsModel` | Serializes webhook URLs and method; `DescribeModel` returns `""`. |
+| `IndicatorSettings` | `Indicator` | `IndicatorSettingsModel` | Pins, warnings, journal entries, color replication; `DescribeModel` returns `""`. |
+| `LeverSettings` | `Lever` | `LeverSettingsModel` | Calls `UpdateOutputState()`. |
+| `ManufactorySettings` | `Manufactory` | `CachableStringSettingModel<RecipeSpec>` | Guards: skips if recipe is unchanged or not in `ProductionRecipes`, or only one recipe exists. Accesses private `_recipeSpecs` dictionary. |
+| `MemorySettings` | `Memory` | `MemorySettingsModel` | Entity-id (3 GUIDs); connects inputs via `TryConnecting`. |
+| `PausableBuildingSettings` | `PausableBuilding` | `BoolSettingModel` | `Order = 100` (applied first, before other settings). |
+| `PlantablePrioritizerSettings` | `PlantablePrioritizer` | `CachableStringSettingModel<PlantableSpec>` | Guards on `AllowedPlantables` membership. |
+| `PopulationCounterSettings` | `PopulationCounter` | `PopulationCounterSettingsModel` | Extends `ComparisonSettingsModel`; calls `Sample()`. |
+| `PowerMeterSettings` | `PowerMeter` | `PowerMeterSettingsModel` | Handles both int-threshold and percent-threshold modes. |
+| `RelaySettings` | `Relay` | `RelaySettingsModel` | Entity-id (2 GUIDs); calls `Evaluate()`. |
+| `ResourceCounterSettings` | `ResourceCounter` | `ResourceCounterSettingsModel` | Silently skips unknown good IDs; calls `InvokeGoodChangeEvent` and `Sample()`. |
+| `ScienceCounterSettings` | `ScienceCounter` | `ComparisonSettingsModel` | Casts threshold to `int`. |
+| `SingleGoodAllowerSettings` | `SingleGoodAllower` | `CachableStringSettingModel<GoodSpec>` | Guards on `inventory.Takes(id)`. |
+| `SluiceSettings` | `Sluice` | `SluiceSettingsModel` | Model carries a `[JsonIgnore] SluiceState` built from record fields; applies via `SetStateAndSynchronize`. |
+| `SpeakerSettings` | `Speaker` | `SpeakerSettingsModel` | Validates sound ID via `SpeakerSoundService`; calls `StopAndPlayIfContinuous()`. |
+| `StockpilePrioritySettings` | `StockpilePriority` | `ValueSettingModel<StockpilePriorityState>` | Local `StockpilePriorityState` enum defined in the same file. |
+| `TimedComponentActivatorSettings` | `TimedComponentActivator` | `TimedComponentActivatorSettingsModel` | Constructs a temp `TimedComponentActivator(null,null,null,null)` and calls `DuplicateFrom`; `DescribeModel` returns `""`. |
+| `TimerSettings` | `Timer` | `TimerSettingsModel` | Entity-id (2 GUIDs); two `TimerInterval` sub-models; accesses private `_hours` on interval. |
+| `UnstableCoreSettings` | `UnstableCore` | `IntSettingModel` | Explosion radius. |
+| `ValveSettings` | `Valve` | `ValveSettingsModel` | Calls `SynchronizeNeighbors()`; `DescribeModel` returns `""`. |
+| `WaterInputCoordinatesSettings` | `WaterInputCoordinates` | `WaterInputCoordinatesSettingsModel` | Clamps to `_waterInputSpec.MaxDepth`; calls `UpdateCoordinatesAndDepth()`. |
+| `WaterMoverSettings` | `WaterMover` | `WaterMoverSettingsModel` | Implements `ILoadableSingleton` itself to cache good display names on load (separate from the base class `Load()`). |
+| `WaterSourceRegulatorSettings` | `WaterSourceRegulator` | `WaterSourceRegulatorSettingsModel` | Accesses private `_regulatorState`. |
+| `WaterSourceSettings` | `WaterSource` | `FloatSettingModel` | `SpecifiedStrength`. |
+| `WeatherStationSettings` | `WeatherStation` | `WeatherStationSettingsModel` | Calls `UpdateOutputState()`. |
+| `WorkplacePrioritySettings` | `WorkplacePriority` | `PrioritySettingModel` | — |
+| `WorkplaceSettings` | `Workplace` | `IntSettingModel` | Caps `DesiredWorkers` at `MaxWorkers`. |
+| `WorkplaceWorkerTypeSettings` | `WorkplaceWorkerType` | `StringSettingModel` | Guards on `IsWorkerTypeAllowed` and `IsWorkerTypeUnlocked`. |
+
+## How it fits together
+
+Every class here extends either `BuildingSettingsBase<T, TModel>` or `EntityIdBuildingSettingsBase<T, TModel>`. The two abstract methods are `GetModel` (snapshot the component to a record) and `ApplyModel` (push a deserialized record back to the component). Handlers that need to look up game services (recipes, goods, entity registry, etc.) receive them via constructor injection — the DI container wires them because `BuildingSettingsConfig` registers all of them as singletons.
+
+`CachableStringSettingModel<T>` is the go-to pattern whenever the serialized value is a string ID (recipe ID, template name, good ID) and display needs a resolved name: the first `EnsureModelCache` / `EnsureCached` call populates `CachedValue` and `CachedDisplay`, subsequent calls are no-ops.
+
+Entity-linked handlers (`AutomatableSettings`, `RelaySettings`, `MemorySettings`, `TimerSettings`) inherit `EntityIdBuildingSettingsBase` and expose the remapping overload for cross-save paste.
+
+## Dependencies & patterns
+
+- **Timberborn game components:** Direct access to internal/private fields (e.g., `_gateOpeningMode`, `_customColor`, `_sluiceState`, `_recipeSpecs`, `_hours`, `_rawThreshold`) via the modding assembly which exposes them.
+- **`ILoc`:** All handlers accept it for localized descriptions and `TNone()` / `TYesNo()` helpers.
+- **`EntityRegistry`:** Used by entity-id handlers to resolve `Automator` by GUID and to format `DescribeEntity`.
+- **`IGoodService`, `RecipeSpecService`, `FireworkSpecService`, `SpeakerSoundService`, `TemplateNameMapper`, `WorkerTypeHelper`:** Injected where needed for lookups and display text.
+- **No Harmony patches** in this subfolder.
+- **`[JsonIgnore]`** on computed/cached properties in models; **`[JsonConstructor]`** on `CachableStringSettingModel<T>` to avoid ambiguity.
+
+## Notes / gotchas
+
+- `WaterMoverSettings` overrides `ILoadableSingleton.Load()` with `base.Load()` followed by its own logic; the explicit interface implementation is required because `BuildingSettingsBase` also implements `ILoadableSingleton`.
+- `TimedComponentActivatorSettings` constructs `TimedComponentActivator(null, null, null, null)` to call `DuplicateFrom` — relies on the game component being null-safe in that constructor.
+- `StockpilePriorityState` enum is defined locally in `StockpilePrioritySettings.cs`, not in the shared models file.

--- a/ModdableTimberborn/BuildingSettings/README.md
+++ b/ModdableTimberborn/BuildingSettings/README.md
@@ -1,0 +1,38 @@
+# BuildingSettings
+
+## Purpose
+
+Defines a generic serialization/deserialization framework for copying building configuration between buildings (the "duplicate settings" feature). Each `IBuildingSettings` implementation knows how to snapshot one `IDuplicable` component type to JSON and reapply it to another instance of the same type. This lets the mod transfer virtually any building's state atomically and consistently.
+
+## Key types
+
+- **`IBuildingSettings`** — core interface: `Serialize`, `Deserialize`, `DescribeDuplicable`, `DescribeModel`, `CanDeserialize`, `GetComponent`. Has a typed generic variant `IBuildingSettings<T, TModel>` that provides covariant default bridge implementations.
+- **`BuildingSettingsBase<T, TModel>`** — abstract base for most concrete handlers. Implements `ILoadableSingleton` to lazily resolve the localized `Name` key (`LV.MT.BldSet.<TypeName>`). Serializes via `JsonConvert`, applies via `ApplyModel`, and exposes a `DeserializeInternal` helper with optional model transformation.
+- **`EntityIdBuildingSettingsBase<T, TModel>`** — extends `BuildingSettingsBase` for handlers whose model contains entity GUIDs. During deserialization it remaps those GUIDs through an `idMappings` dictionary (used when the source and target saves have different entity IDs — i.e., copy-paste across saves).
+- **`IEntityIdBuildingSettings` / `IEntityIdBuildingSettingsBase<T, TModel>`** — interface pair marking handlers that need GUID remapping; callers use these to decide whether to pass an `idMappings` dictionary.
+- **`IEntityIdModel` / `EntityIdModelBase`** — model base that exposes a `Guid?[]` slot array so `EntityIdBuildingSettingsBase` can do the GUID substitution loop generically.
+- **`BuildingSettingsResolver`** — singleton that aggregates all `IBuildingSettings` instances injected via multibind, indexes them by `Type` into a `FrozenDictionary`, and exposes `Get(Type)`, `Get(IDuplicable)`, and `Get(BaseComponent[, filter])` helpers. Also caches the per-template component list in a `Dictionary<string, ImmutableArray<IBuildingSettings>>` to avoid repeated reflection.
+- **`BuildingSettingsPair`** — lightweight `readonly record struct(IDuplicable, IBuildingSettings)` returned from resolver lookups.
+- **`BuildingSettingsConfig`** — `IModdableTimberbornRegistryConfig` that registers `BuildingSettingsResolver` as a singleton and auto-discovers every concrete `IBuildingSettings` class in the assembly via reflection, binding each as a multibind singleton. Activated through `ModdableTimberbornRegistry.UseBuildingSettings()`.
+
+## How it fits together
+
+`BuildingSettingsConfig.Configure` scans the assembly for all non-abstract `IBuildingSettings` implementations and registers them as a multibound collection under `IBuildingSettings`. At game load, Bindito injects this collection into `BuildingSettingsResolver`, which builds the `FrozenDictionary<Type, IBuildingSettings>` index and the ordered `AllBuildingSettings` array.
+
+The typical consumer (e.g., a UI panel or a blueprint copier) calls `BuildingSettingsResolver.Get(BaseComponent)` to get `BuildingSettingsPair[]` for a target building — one pair per duplicable component — then calls `pair.Settings.Serialize(pair.Duplicable)` to snapshot, and `pair.Settings.Deserialize(json, targetDuplicable)` to reapply. For entity-linked settings the caller checks `IEntityIdBuildingSettings` and passes the GUID map.
+
+The concrete handlers live in `BuiltInSettings/` and cover all stock Timberborn `IDuplicable` component types.
+
+## Dependencies & patterns
+
+- **Bindito (DI):** `[MultiBind]` pattern via `configurator.MultiBind(typeof(IBuildingSettings), t).AsSingleton()` — no attribute, done reflectively in config.
+- **Newtonsoft.Json:** `JsonConvert.SerializeObject` / `DeserializeObject` used directly in `BuildingSettingsBase`; some models carry `[JsonIgnore]` and `[JsonConstructor]` attributes.
+- **`ILoadableSingleton`:** Used by `BuildingSettingsBase` (to resolve localized name on load) and `BuildingSettingsResolver` (to run optional dev-time validation).
+- **`ILoc`:** Timberborn localization service, injected into every handler and base class.
+- **No Harmony patches** in this folder.
+
+## Notes / gotchas
+
+- `BuildingSettingsResolver.ValidateBuildingSettingsHandler()` is commented out (`// Only run while developing`) — it would log warnings for any `IDuplicable` component type lacking a handler. Uncomment for coverage audits.
+- The `Order` property on `IBuildingSettings` defaults to `1000`; `PausableBuildingSettings` overrides it to `100` so pause state is applied before other settings. Ordering matters if downstream consumers apply settings in sequence.
+- Assembly auto-discovery in `BuildingSettingsConfig` means any new concrete `IBuildingSettings` added to the assembly is registered automatically — no manual wiring needed.

--- a/ModdableTimberborn/Common/README.md
+++ b/ModdableTimberborn/Common/README.md
@@ -1,0 +1,42 @@
+# Common
+
+## Purpose
+
+Shared abstractions and base types used across the ModdableTimberborn library. Defines the core modifier/value pipeline (how arbitrary numeric or typed values get transformed by a priority-ordered stack of modifiers) and the togglable-container pattern (how a component that owns a set of child components can be activated/deactivated while keeping event wiring consistent).
+
+## Key types
+
+- **`IModdableModifier`** — Base modifier interface: `Id`, `Priority`, `Disabled`, and `OnChanged` event. All modifiers implement this.
+- **`IModdableModifier<TModdableValue, TValue>`** — Typed extension; adds `Modify(TModdableValue)` which mutates the value in-place and returns `true` to short-circuit the chain.
+- **`IModdableValue<TValue>` / `ModdableValue<TValue>`** — Holds both the live `Value` and the `OriginalValue` that was set before modifiers ran. `ModdableValue<T>` is the concrete implementation; supports deconstruction.
+- **`ModdableValueChanged<TValue>`** — Immutable `readonly record struct` carrying `(NewValue, OldValue)` for change-event payloads.
+- **`ModifierCollection<T>`** — Owns an `ImmutableArray<T>` of modifiers sorted by `Priority` at construction, subscribes to each modifier's `OnChanged` to mark itself dirty. Implements `IDisposable` to unsubscribe.
+- **`ValueModifierCollection<T, TModdableValue, TValue>`** — Extends `ModifierCollection` with a `Modify(TModdableValue, forceDirty)` method: resets value to original, walks the sorted modifier list skipping disabled entries, stops early on a short-circuit, clears `IsDirty`, and returns whether the value actually changed.
+- **`PriorityItem<T>`** — Generic `record` wrapping an item with a priority int; implements `IComparable<PriorityItem<T>>` with hash-code tiebreaking.
+- **`IModifiableEvent<TModifier, TValue>`** — Interface representing an in-flight event that carries a modifier list, original value, and a mutable current value (used in event-based modifier patterns).
+- **`ITogglableContainer<TContainer, TMember>`** — Interface for an activate/deactivate relationship between a container `BaseComponent` and its member `BaseComponent`s. Exposes `Toggle(bool)`, default `Activate()`/`Deactivate()` helpers, and a `Toggled` event.
+- **`BaseTogglableContainer<TContainer, TMember>`** — Abstract non-Unity class implementing `ITogglableContainer`. Guards against redundant toggles; calls abstract `PerformActivate`/`PerformDeactivate` and fires the `Toggled` event.
+- **`BaseEventTogglableContainer<TContainer, TMember>`** — Extends `BaseTogglableContainer`: activation calls `AddEventHandlers()` then `OnMemberAdded` for each existing member; deactivation calls `RemoveEventHandlers()` then `OnMemberRemoved`. Concrete subclasses supply those four abstract methods.
+- **`BaseEventTogglableContainerComponent<TTogglable, TContainer, TMember>`** — Unity `BaseComponent` wrapper. `Awake` creates the inner `TTogglable` data object (via abstract `CreateData`) and forwards its `Toggled` event to its own.
+- **`BaseModdableComponent<TComponent>`** — Thin `BaseComponent` subtype that exposes `OriginalComponent` — a reference to the vanilla Timberborn component being modded/extended.
+- **`IModdableComponentAwake` / `IModdableComponentStart`** — Marker interfaces with `AwakeAfter()` / `StartAfter()` hooks, called after Unity's own `Awake`/`Start` lifecycle methods.
+
+## How it fits together
+
+The modifier pipeline flows like this: a concrete value holder wraps a `ModdableValue<T>`, a `ValueModifierCollection` is created from all `IModdableModifier` components on the same `BaseComponent`, and whenever the collection is dirty (any modifier fired `OnChanged`) a call to `Modify(value)` resets the value to its original and walks the sorted, non-disabled modifier list. Modifiers mutate `IModdableValue.Value` directly and may short-circuit. The return value signals whether anything changed, letting callers decide whether to broadcast downstream.
+
+The togglable-container hierarchy separates data logic from Unity lifecycle: `BaseTogglableContainer` / `BaseEventTogglableContainer` are plain C# classes (no Unity dependency) and hold the activate/deactivate state machine. `BaseEventTogglableContainerComponent` bridges into Unity — it creates the data object in `Awake` and delegates to it. Feature-specific containers (elsewhere in the project) inherit from `BaseEventTogglableContainer` and supply the event-wiring and per-member callbacks.
+
+`BaseModdableComponent<T>` and the `IModdableComponentAwake`/`IModdableComponentStart` interfaces are the entry point for the modding side: when ModdableTimberborn patches a vanilla component, it sets `OriginalComponent` on the modded wrapper and calls `AwakeAfter`/`StartAfter` to let the mod run post-vanilla-initialization logic.
+
+## Dependencies & patterns
+
+- **Timberborn / Unity:** `BaseComponent` is a Timberborn wrapper around `UnityEngine.MonoBehaviour`. `GetComponent`/`GetComponents` are Unity APIs used in `ModifierCollection` and `BaseEventTogglableContainerComponent.Awake`.
+- **No DI registration here:** Common contains only abstract base types and interfaces; DI bindings (`[MultiBind]`, configurators) are handled by feature-specific modules that consume these types.
+- **No Harmony patches** in this folder; patching is done elsewhere.
+- **`ImmutableArray<T>`** (System.Collections.Immutable) used in `ModifierCollection` — modifier list is fixed at construction time; runtime changes require a new collection.
+
+## Notes / gotchas
+
+- `PriorityItem<T>` tiebreaks by `GetHashCode()` comparison, which is arbitrary and non-deterministic for types without a stable hash. Two items at the same priority with the same hash code compare as equal, which could cause unexpected behavior in sorted structures.
+- `IModifiableEvent` is defined in this folder and consumed by event-bus-style modifier patterns implemented in feature-specific modules.

--- a/ModdableTimberborn/CompatWeatherService/README.md
+++ b/ModdableTimberborn/CompatWeatherService/README.md
@@ -1,0 +1,38 @@
+# CompatWeatherService
+
+## Purpose
+
+Provides a stable, mod-friendly abstraction over Timberborn's internal weather system. Because the game's weather API may change between versions (or differ when other mods are present), this subsystem decouples consumers from concrete game types by routing all weather queries through a priority-selected provider. The default implementation wraps the vanilla `WeatherService`, `HazardousWeatherService`, and `GameCycleService`.
+
+## Key Types
+
+- **`CompatWeatherService`** — Singleton entry point. Resolves the highest-priority registered `ICompatWeatherServiceProvider` at construction time and exposes it as the single `Provider` property. Throws if no provider is registered.
+- **`ICompatWeatherServiceProvider`** — The abstraction contract. Covers current/next cycle stages, hazardous-weather state, warning status, and the list of known weather types. Implementations declare a `Priority` to win provider selection.
+- **`DefaultCompatWeatherServiceProvider`** — The built-in implementation wrapping vanilla game services (priority `-1`, so any mod-supplied provider wins by default). Enumerates the three stock weather types: Temperate, Drought, and Badtide.
+- **`CompatWeatherType`** — Readonly record: a weather type's string `Id`, display localisation key (`DisplayLoc`), and `IsBenign` flag.
+- **`CompatWeatherCycle`** — Represents a full weather cycle: cycle number and an ordered array of `CompatWeatherCycleStage` entries. `Length` sums all stage lengths (returns 1 for empty stage arrays to avoid a zero-length cycle).
+- **`CompatWeatherCycleStage`** — A single stage within a cycle: cycle index, stage index, `StartDay`, `Length`, `WeatherId`, and `IsBenign`. `LastDay` is a derived convenience property.
+- **`CompatNextWeatherCycleStage`** — Like `CompatWeatherCycleStage` but with nullable `Length`, `WeatherId`, and `IsBenign` to represent a future stage whose details may not yet be known. Includes an implicit conversion from `CompatWeatherCycleStage`.
+- **`CompatWeatherWarning`** — Snapshot of the current hazard-approach warning: `Stage` enum, `DaysToHazardous` (float, nullable), and `NextWeatherId`.
+- **`CompatWeatherWarningStage`** (enum) — `NoWarning`, `ShowedToday`, `Showing`, `Hazardous`, `NoHazardous`.
+
+## How It Fits Together
+
+`CompatWeatherService` is a `[BindSingleton]` that receives all registered `ICompatWeatherServiceProvider` instances via DI constructor injection. On creation it picks the one with the highest `Priority` and exposes it as `Provider`. Consumers depend on `CompatWeatherService` and call `Provider.*` for all weather queries — they never touch the game's `WeatherService` directly.
+
+`DefaultCompatWeatherServiceProvider` is registered via `[MultiBind(typeof(ICompatWeatherServiceProvider))]`, making it part of the DI multi-binding collection automatically. Other mods or assemblies can supply competing implementations with a higher priority (any value `>= 0` beats the default's `-1`) to override weather data without touching existing consumers.
+
+The provider builds cycle/stage objects on-the-fly from live game-service data; nothing is cached. Warning logic in `GetWarningStatus` uses `HazardousWeatherApproachingTimer.DaysToHazardousWeather` and the timer's spec to classify the warning into one of the five `CompatWeatherWarningStage` buckets.
+
+## Dependencies & Patterns
+
+- **Bindito (DI):** `[BindSingleton]` on `CompatWeatherService`; `[MultiBind(typeof(ICompatWeatherServiceProvider))]` on `DefaultCompatWeatherServiceProvider` for the provider collection pattern.
+- **Timberborn game services injected into `DefaultCompatWeatherServiceProvider`:** `WeatherService`, `GameCycleService`, `HazardousWeatherService`, `HazardousWeatherApproachingTimer`.
+- **Unity:** `Mathf.CeilToInt` used in warning-stage boundary calculation.
+- **`ImmutableArray<T>`** (System.Collections.Immutable) for the stage list in `CompatWeatherCycle` and the static `GameWeathers` array.
+- No Harmony patches in this folder; no serialization attributes.
+
+## Notes / Gotchas
+
+- Priority `-1` for the default is intentional: any externally registered provider with priority `0` or above takes over entirely. Consumers should be aware that `Provider` is fully replaced, not composed — there is no fallback or chaining.
+- `GetNextCycleStage` returns a next-cycle stage with `null` Length/WeatherId when the current cycle has no hazardous stage and the game is already in (or past) hazardous weather; consumers must handle nullable fields on `CompatNextWeatherCycleStage`.

--- a/ModdableTimberborn/DependencyInjection/Patches/README.md
+++ b/ModdableTimberborn/DependencyInjection/Patches/README.md
@@ -1,0 +1,23 @@
+# DependencyInjection/Patches
+
+## Purpose
+
+Harmony postfix patches that hook into Timberborn's two main data-loading methods and forward control to ModdableTimberborn's runner services. These patches are the bridge between the game's load sequence and the mod's modification pipeline.
+
+## Key types
+
+- **`SpecServicePatches`** — Postfixes `SpecService.Load`; retrieves `SpecServiceRunner` from the DI container and calls `OnSpecLoaded`.
+- **`TemplateCollectionServicePatches`** — Postfixes `TemplateCollectionService.Load` at `HarmonyPriority.First`; retrieves `TemplateCollectionTailRunnerService` and calls `Run`.
+
+## How it fits together
+
+Both patches are decorated with `[HarmonyPatchCategory(ModdableDependencyInjectionConfig.PatchCategoryName)]` so they are only activated when `ModdableDependencyInjectionConfig` is registered (i.e., when the DependencyInjection subsystem is in use). They use `ContainerRetriever` to pull the relevant service from the active DI container at runtime, avoiding any tight compile-time coupling.
+
+## Dependencies & patterns
+
+- **Harmony**: Standard postfix attribute-based patches. `TemplateCollectionServicePatches` additionally sets `HarmonyPriority.First` to ensure it runs before any other mods that might also patch `TemplateCollectionService.Load`.
+- **`ContainerRetriever`**: Timberborn/Bindito utility for accessing the DI container from static Harmony patch methods.
+
+## Notes / gotchas
+
+- No cleanup / unpatch is performed explicitly; patch lifecycle is managed by the Harmony category registration in `ModdableDependencyInjectionConfig`.

--- a/ModdableTimberborn/DependencyInjection/README.md
+++ b/ModdableTimberborn/DependencyInjection/README.md
@@ -1,0 +1,46 @@
+# DependencyInjection
+
+## Purpose
+
+Provides the infrastructure for mods to intercept and modify Timberborn's data-loading pipeline at two points: the `SpecService` (component-spec blueprints) and the `TemplateCollectionService` (prefab templates). It introduces a hook-and-runner pattern so individual mod services can register modifications without patching game code directly, and supplies a few utility types (`AssetRefService`, `EditableBlueprint`) that support those modifications.
+
+## Key types
+
+- **`ModdableDependencyInjectionConfig`** — Bindito configurator that wires all runners and services for this subsystem. Also contains a partial extension to `ModdableTimberbornRegistry` for opt-in registration. Implements `IModdableTimberbornRegistryWithPatchConfig`, so it also activates the Harmony patches in the `Patches/` subfolder.
+- **`EditableBlueprint`** — Mutable wrapper around an immutable `Blueprint`. Holds `Name`, `Children`, and `Specs` as editable lists; converts back to `Blueprint` via `ToBlueprint()` / implicit cast. The main currency passed between `ISpecModifier` and `ITemplateModifier` implementations.
+- **`AssetRefService`** — Thin wrapper around `IAssetLoader` that lazily creates `AssetRef<T>` instances. Registered as a bootstrapper-context singleton so it is available very early in startup.
+- **`ISpecModifier` / `BaseBlueprintModifier<T>`** — Interface and abstract base for modifying a batch of `EditableBlueprint`s keyed by `ComponentSpec` type. Supports `Order` and `ShouldRun` guards.
+- **`BaseSpecModifier<T>`** — Convenience base that unpacks blueprints into `NamedSpec<T>` records so implementors only deal with named specs, not full blueprints. Use only when each blueprint has exactly one spec of type `T`.
+- **`BaseSpecTransformer<T>`** — Convenience base that applies a single `Transform(T spec) -> T?` call per blueprint in-place; simpler than `BaseSpecModifier` when the blueprint structure does not change.
+- **`SpecModifierService`** — `ISpecServiceTailRunner` that groups all registered `ISpecModifier`s by their target `ComponentSpec` type, then applies them in `Order` sequence after `SpecService.Load`.
+- **`SpecServiceRunner`** — Coordinator (`IBlueprintModifierProvider`, `ILoadableSingleton`) that fires all `ISpecServiceTailRunner`s after `SpecService.Load`; also ensures `ISpecServiceFrontRunner`s are constructed (and thus their `ILoadableSingleton.Load` runs) before the spec load.
+- **`ISpecServiceFrontRunner`** — Marker interface; services that implement it get their `Load()` called *before* `SpecService.Load`. Registration only; no additional method needed beyond `ILoadableSingleton`.
+- **`ISpecServiceTailRunner`** — Services with a `Run(SpecService)` called *after* `SpecService.Load`.
+- **`ITemplateCollectionServiceTailRunner`** — Services with a `Run(TemplateCollectionService)` called *after* `TemplateCollectionService.Load`. Supports `Order`.
+- **`ITemplateModifier`** — Fine-grained interface for modifying individual templates; receives blueprint name, template name, and the original `TemplateSpec`. Must implement `ShouldModify` (gate) and `Modify` (transform, returning null for no change).
+- **`TemplateCollectionTailRunnerService`** — Coordinator (`ITemplateCollectionIdProvider`) that fans out to all registered `ITemplateCollectionServiceTailRunner`s in order.
+- **`TemplateModifierTailRunner`** — `ITemplateCollectionServiceTailRunner` that applies all `ITemplateModifier`s to `TemplateCollectionService.AllTemplates`, updates `blueprintSourceService` for changed templates, and replaces the collection in-place.
+
+## How it fits together
+
+`ModdableDependencyInjectionConfig.Configure` is the single entry point that registers everything. In the **bootstrapper context** it only registers `AssetRefService`. In all other contexts it registers the two coordinator chains:
+
+1. **Spec chain**: `SpecServiceRunner` (multi-bound as `IBlueprintModifierProvider`) collects `ISpecServiceFrontRunner`s (loaded before spec load) and `ISpecServiceTailRunner`s (run after). The built-in tail runner `SpecModifierService` (registered via `BindSpecTailRunner`) then dispatches to all multi-bound `ISpecModifier`s. Consumers register their own `ISpecModifier` implementations with `configurator.BindSpecModifier<T>()` or `ISpecServiceTailRunner` implementations with `configurator.BindSpecTailRunner<T>()`.
+
+2. **Template chain**: `TemplateCollectionTailRunnerService` (multi-bound as `ITemplateCollectionIdProvider`) collects `ITemplateCollectionServiceTailRunner`s in order. `TemplateModifierTailRunner` (registered via `BindTemplateTailRunner`) is the built-in runner that fans out to all `ITemplateModifier`s. Consumers register their modifiers with `configurator.BindTemplateModifier<T>()` or full runners with `configurator.BindTemplateTailRunner<T>()`.
+
+The Harmony patches in `Patches/` trigger both chains: `SpecServicePatches` postfixes `SpecService.Load` to invoke `SpecServiceRunner.OnSpecLoaded`, and `TemplateCollectionServicePatches` postfixes `TemplateCollectionService.Load` to invoke `TemplateCollectionTailRunnerService.Run`. Both patches are gated by `ModdableDependencyInjectionConfig.PatchCategoryName` so they only activate when this config is registered.
+
+Mod authors opt in either by implementing `IWithDIConfig` on their configurator class (preferred) or by calling `registry.UseDependencyInjection()` (deprecated).
+
+## Dependencies & patterns
+
+- **Bindito (DI)**: `[MultiBind]` / `configurator.MultiBindSingleton` for collecting open-ended lists of `ISpecModifier`, `ISpecServiceTailRunner`, `ITemplateModifier`, and `ITemplateCollectionServiceTailRunner`. Singletons throughout.
+- **Harmony**: Two postfix patches (`SpecServicePatches`, `TemplateCollectionServicePatches`). Both use `ContainerRetriever` to pull services out of the DI container at patch time. Both are in category `ModdableTimberborn.DependencyInjection`.
+- **Timberborn game types**: `SpecService`, `TemplateCollectionService`, `Blueprint`, `ComponentSpec`, `TemplateSpec`, `BlueprintAsset`, `IAssetLoader`, `BlueprintSourceService`, `ITemplateCollectionIdProvider`, `IBlueprintModifierProvider`.
+- `FrozenDictionary` and `ImmutableArray` used in `SpecModifierService` and the runner services for read-only, allocation-minimal dispatch after load.
+
+## Notes / gotchas
+
+- `SpecServiceRunner.Load()` is intentionally empty; the `ILoadableSingleton` implementation exists only to force construction (and therefore front-runner loading) at the right time. The `#pragma warning disable CS9113` suppressing "parameter is unread" on `frontRunners` is a deliberate DI side-effect trick.
+- `UseDependencyInjection()` on `ModdableTimberbornRegistry` is `[Obsolete]`; the idiomatic replacement is adding `IWithDIConfig` to the mod's own config class.

--- a/ModdableTimberborn/DependencyInjection/Specs/README.md
+++ b/ModdableTimberborn/DependencyInjection/Specs/README.md
@@ -1,0 +1,34 @@
+# DependencyInjection/Specs
+
+## Purpose
+
+Defines the interfaces and abstract base classes for modifying Timberborn's component-spec blueprints after `SpecService.Load`, plus the two services that coordinate the execution of those modifications.
+
+## Key types
+
+- **`ISpecServiceFrontRunner`** — Marker interface extending `ILoadableSingleton`. Services bound to this interface have their `Load()` called *before* `SpecService.Load`. No extra methods required.
+- **`ISpecServiceTailRunner`** — Interface with a single `Run(SpecService)` method called *after* `SpecService.Load`.
+- **`ISpecModifier`** — Core modification interface. Provides `Type` (the `ComponentSpec` type to target), `Order` (execution priority), `ShouldRun` (runtime gate), and `Modify(IEnumerable<EditableBlueprint>) -> IEnumerable<EditableBlueprint>`.
+- **`BaseBlueprintModifier<T>`** — Abstract base implementing `ISpecModifier`; sets `Type` from the generic parameter and leaves `Modify` abstract.
+- **`NamedSpec<T>`** — Readonly record struct pairing a blueprint name with a single typed spec, used by `BaseSpecModifier<T>`.
+- **`BaseSpecModifier<T>`** — Extends `BaseBlueprintModifier<T>`; unpacks blueprints into `NamedSpec<T>` records and reconstructs them after modification. Use when each blueprint has exactly one spec of type `T` and no children need to be preserved.
+- **`BaseSpecTransformer<T>`** — Extends `BaseBlueprintModifier<T>`; iterates blueprints and calls `Transform(T) -> T?` on each matching spec in place. Simpler than `BaseSpecModifier` when structural changes to the blueprint are not needed.
+- **`SpecModifierService`** — `ISpecServiceTailRunner` that groups all multi-bound `ISpecModifier`s by `Type` into a `FrozenDictionary`, then applies them in `Order` sequence to the relevant blueprints in `SpecService._cachedBlueprintsBySpecs`.
+- **`SpecServiceRunner`** — `IBlueprintModifierProvider` and `ILoadableSingleton` coordinator. Injected with both front-runner and tail-runner collections; fires all tail runners after `SpecService.Load` via `OnSpecLoaded`.
+
+## How it fits together
+
+Mod authors create a class inheriting `BaseSpecModifier<T>` or `BaseSpecTransformer<T>` (or implementing `ISpecModifier` directly) and register it with `configurator.BindSpecModifier<T>()`. `SpecModifierService` aggregates all such modifiers and is itself registered as an `ISpecServiceTailRunner` via `BindSpecTailRunner`. `SpecServiceRunner` collects all tail runners and is triggered by the Harmony postfix in `Patches/SpecServicePatches.cs`.
+
+For more control over the full `SpecService` state (not just per-type blueprint batches), a mod can implement `ISpecServiceTailRunner` directly and register with `BindSpecTailRunner`.
+
+## Dependencies & patterns
+
+- **Bindito multi-bind**: `ISpecModifier` and `ISpecServiceTailRunner` are both collected as `IEnumerable<T>` in their respective consumers.
+- **`FrozenDictionary` / `ImmutableArray`**: Used in `SpecModifierService` for efficient dispatch after construction.
+- **Timberborn internals**: `SpecModifierService.Run` accesses `SpecService._cachedBlueprintsBySpecs` via reflection to read the cached blueprint map.
+
+## Notes / gotchas
+
+- `SpecServiceRunner.Load()` is intentionally empty; the `ILoadableSingleton` implementation is only there to ensure the front-runners' `Load()` calls are sequenced correctly by the DI framework.
+- The `frontRunners` constructor parameter of `SpecServiceRunner` is suppressed with `#pragma warning disable CS9113` — it is injected solely for side-effect (forcing front-runner construction), not used directly.

--- a/ModdableTimberborn/DependencyInjection/TemplateCollection/README.md
+++ b/ModdableTimberborn/DependencyInjection/TemplateCollection/README.md
@@ -1,0 +1,30 @@
+# DependencyInjection/TemplateCollection
+
+## Purpose
+
+Defines the interfaces and services for modifying Timberborn's prefab templates (the `TemplateCollectionService`) after they are loaded. Mirrors the Specs pipeline but targets template blueprints identified by `TemplateSpec`.
+
+## Key types
+
+- **`ITemplateCollectionServiceTailRunner`** — Interface with `Run(TemplateCollectionService)` and an `Order` priority. Services implementing this are called after `TemplateCollectionService.Load`.
+- **`ITemplateModifier`** — Fine-grained interface for per-template modifications. Provides `Order`, a `ShouldModify(blueprintName, templateName, originalTemplateSpec)` gate, and `Modify(EditableBlueprint, TemplateSpec, Blueprint) -> EditableBlueprint?` (return null for no change).
+- **`TemplateCollectionTailRunnerService`** — `ITemplateCollectionIdProvider` coordinator that collects all `ITemplateCollectionServiceTailRunner`s (sorted by `Order`) and dispatches to them. Also implements the `GetPrefabGroups` and `GetTemplateCollectionIds` stubs (both return empty).
+- **`TemplateModifierTailRunner`** — `ITemplateCollectionServiceTailRunner` that iterates `TemplateCollectionService.AllTemplates`, applies all registered `ITemplateModifier`s, records blueprint-source metadata for changed templates via `BlueprintSourceService`, and replaces `AllTemplates` in-place if any changes were made.
+
+## How it fits together
+
+Mod authors implement `ITemplateModifier` and register with `configurator.BindTemplateModifier<T>()`. `TemplateModifierTailRunner` (registered via `BindTemplateTailRunner`) collects all modifiers and applies them in `Order` sequence. `TemplateCollectionTailRunnerService` coordinates all tail runners (including `TemplateModifierTailRunner`) and is triggered by the Harmony postfix in `Patches/TemplateCollectionServicePatches.cs`.
+
+For broader control over the full template collection (not per-template), a mod can implement `ITemplateCollectionServiceTailRunner` directly and register with `BindTemplateTailRunner`.
+
+## Dependencies & patterns
+
+- **Bindito multi-bind**: Both `ITemplateCollectionServiceTailRunner` and `ITemplateModifier` are collected as `IEnumerable<T>`.
+- **`BlueprintSourceService`**: `TemplateModifierTailRunner` calls `blueprintSourceService.Get(original).AddJson("{}", TypeName)` to register a source record for each modified template, maintaining Timberborn's blueprint provenance tracking.
+- **`ImmutableArray`**: Both runner services freeze their injected collections at construction time.
+- **`TemplateSpec`**: The gate for `ITemplateModifier`; only blueprints that have a `TemplateSpec` are considered.
+
+## Notes / gotchas
+
+- `TemplateModifierTailRunner` uses the type's own `FullName` as a source tag string (`TypeName = typeof(TemplateModifierTailRunner).FullName`); this is a static field so it is computed once at class load.
+- Passing `"{}"` as the JSON content to `AddJson` registers a source entry so Timberborn knows the blueprint was modified, but does not record actual diff data.

--- a/ModdableTimberborn/EnterableSystem/README.md
+++ b/ModdableTimberborn/EnterableSystem/README.md
@@ -1,0 +1,38 @@
+# EnterableSystem
+
+## Purpose
+
+Provides base components that hook into Timberborn's `Enterable`/`Enterer` system so that effects (bonuses, tick-based logic) can be applied to characters while they are inside an enterable building, with the whole effect optionally toggled on/off. It bridges the generic togglable-container infrastructure in `Common` with Timberborn's enterable events.
+
+## Key types
+
+- **`TogglableEnterableEffectComponent`** (abstract) — Unity `BaseComponent` that reacts to enter/exit events. Subclass and implement `OnEnter(Enterer)` / `OnExit(Enterer)`. Backed by `TogglableEventEnterableContainer`.
+- **`TogglableEnterableBonusComponent`** (abstract) — Concrete specialisation of the above for bonus-tracker use: on enter it calls `enterer.GetBonusTracker().AddOrUpdate(Bonuses)`, on exit it removes the bonus by id. Requires `ModdableTimberbornRegistry.UseBonusTracker(bool)` to be registered.
+- **`TogglableEventEnterableContainer`** — Non-component data object wiring `Enterable.EntererAdded/EntererRemoved` events to `OnMemberAdded/OnMemberRemoved` in the `BaseEventTogglableContainer` pattern. Only hooks the events while the container is active.
+- **`TogglableEnterableTickEffectComponent`** (abstract) — A `TickableComponent` variant. Implements `ITogglableContainer<Enterable, Enterer>` directly; calls `TickEffect()` every tick when active. Backed by `TogglableEnterableContainer`.
+- **`TogglableEnterableTickEffectComponent<TData>`** (abstract) — Extends the above with a per-`Enterer` data dictionary. Override `GetData(Enterer)` to supply per-enterer state; the dictionary is kept in sync via `EntererAdded/Removed` events wired in `Awake`.
+- **`TogglableEnterableContainer`** — Non-component data object wrapping `Enterable` for the tick variant. Both `PerformActivate` and `PerformDeactivate` are no-ops (toggle state is tracked but no event subscription is needed at the container level; the component layer handles events directly).
+
+## How it fits together
+
+Both component families follow the same structural pattern defined in `Common`:
+
+1. A **component** (`TogglableEnterableEffectComponent` or `TogglableEnterableTickEffectComponent`) attaches to a building `GameObject` that already has an `Enterable` component.
+2. `Awake()` locates the sibling `Enterable` via `GetComponent<Enterable>()` and creates the corresponding data/container object.
+3. The container object tracks toggled state and, when active, either subscribes to `EntererAdded`/`EntererRemoved` events (event variant) or keeps a live `Dictionary<Enterer, TData>` that is updated from the same events (tick variant).
+4. Consumers call `Toggle(bool)` / `Activate()` / `Deactivate()` (from `ITogglableContainer`) to enable or disable the effect; the `Toggled` event fires on state change.
+
+The event variant (`TogglableEnterableEffectComponent`) fires its callbacks immediately on enter/exit and is appropriate for stateless or one-shot effects. The tick variant (`TogglableEnterableTickEffectComponent`) runs `TickEffect()` every game tick and is appropriate for continuous or accumulating effects.
+
+`TogglableEnterableBonusComponent` is the ready-to-use concrete subclass for the common case of applying a `BonusTrackerItem` to enterers; mod code just declares a `BonusTrackerItem Bonuses` property and lets the base class do the work.
+
+## Dependencies & patterns
+
+- **Timberborn:** `Enterable`, `Enterer`, `EntererAddedEventArgs`, `EntererRemovedEventArgs`, `TickableComponent`, `BaseComponent` — all Timberborn game types.
+- **Common (this repo):** `BaseEventTogglableContainerComponent<,,>`, `BaseEventTogglableContainer<,>`, `BaseTogglableContainer<,>`, `ITogglableContainer<,>` in `ModdableTimberborn.Common`.
+- **BonusSystem (this repo):** `BonusTrackerItem`, `GetBonusTracker()` extension (from `ModdableTimberborn.Helpers.CharacterExtensions`). `TogglableEnterableBonusComponent` requires the BonusTracker feature to be opted-in via `ModdableTimberbornRegistry.UseBonusTracker(bool)`.
+- No Harmony patches, no DI configurators, and no serialization in this folder. The components are plain Unity MonoBehaviours/`BaseComponent`s; DI wiring is the caller's responsibility.
+
+## Notes / gotchas
+
+- `TogglableEnterableContainer.PerformActivate()` and `PerformDeactivate()` are empty. The tick component wires events directly in `Awake` (unconditionally) rather than in activate/deactivate — meaning the internal `enterers` dictionary is updated regardless of the `Active` flag. Only `TickEffect()` is gated on `Active`. This differs from the event-variant pattern where event subscription is itself toggled.

--- a/ModdableTimberborn/EntityDescribers/README.md
+++ b/ModdableTimberborn/EntityDescribers/README.md
@@ -1,0 +1,42 @@
+# EntityDescribers
+
+## Purpose
+
+Provides a UI panel fragment that displays "active effects" on a selected entity (or its worker's workplace) in the Timberborn entity inspector. The subsystem defines a pluggable describer pattern so that any component on an entity (or its workplace) can contribute human-readable effect descriptions to a shared panel without coupling to a central registry.
+
+## Key types
+
+- **`IBaseEntityEffectDescriber`** — root marker interface; carries an `Order` property used to sort describers within the panel.
+- **`IEntityEffectDescriber`** — single-effect variant; `Describe(ILoc, IDayNightCycle)` returns one optional `EntityEffectDescription`.
+- **`IEntityMultiEffectsDescriber`** — multi-effect variant; `DescribeAll(...)` returns zero or more descriptions.
+- **`IWorkplaceWorkerEffectDescriber`** — extends `IEntityEffectDescriber` for workplace components that need to describe a per-`Worker` effect.
+- **`IWorkplaceEntityMultiEffectsDescriber`** — multi-effect counterpart of the above for workplaces.
+- **`EntityEffectDescription`** — lightweight `readonly record struct` holding `Title`, `Description`, and an optional `RemainingHours` for time-limited effects.
+- **`EntityEffectDescriberFragment`** — the `IEntityPanelFragment` / `IEntityFragmentOrder` implementation that drives the "Active Effects" panel section (`Order = -100`, so it sorts near the top).
+- **`ModdableEntityDescriberConfigurator`** — `IModdableTimberbornRegistryConfig` that registers `EntityEffectDescriberFragment` as an ordered fragment in the Game context.
+
+## How it fits together
+
+`ModdableEntityDescriberConfigurator` is picked up by `ModdableTimberbornRegistry` and calls `configurator.BindOrderedFragment<EntityEffectDescriberFragment>()`, which registers the fragment with the game's entity inspector panel system.
+
+When an entity is selected, `EntityEffectDescriberFragment.ShowFragment` uses `entity.GetComponents<IBaseEntityEffectDescriber>()` to collect every describer component living on that entity. It also checks whether the entity has a `Worker` with an active workplace, and if so collects `IBaseEntityEffectDescriber` components from the *workplace* entity too — enabling workplace buildings to describe effects they apply to their workers.
+
+`UpdateFragment` iterates both lists in sorted order, dispatches to the appropriate interface variant (`IEntityEffectDescriber` / `IEntityMultiEffectsDescriber` on the entity side; `IWorkplaceWorkerEffectDescriber` / `IWorkplaceEntityMultiEffectsDescriber` on the workplace side), and appends localised lines via `ILoc` (`LV.MT.ActiveEffect`, `LV.MT.ActiveEffectTime`). The panel is hidden entirely when no descriptions are produced.
+
+Consumers add new effect descriptions by implementing one of the four `IBaseEntityEffectDescriber` sub-interfaces directly on a Unity component attached to the relevant entity or building prefab — no central registration is required.
+
+## Dependencies & patterns
+
+- **`ILoc`** — Timberborn localisation service; injected via primary constructor and used for all display strings.
+- **`IDayNightCycle`** — Timberborn time service; passed to describers so they can express time-remaining values.
+- **`Worker` / `Workplace`** — vanilla Timberborn components looked up via `GetComponent` at runtime; no hard DI dependency.
+- **`IEntityPanelFragment` / `IEntityFragmentOrder`** — Timberborn UI fragment contracts; `Order = -100` places this section early in the panel.
+- **`IModdableTimberbornRegistryConfig`** — ModdableTimberborn's own DI configurator hook; context restricted to `ConfigurationContext.Game`.
+- **`BindOrderedFragment<T>`** — Bindito/ModdableTimberborn helper that registers a UI fragment and respects `IEntityFragmentOrder`.
+- No Harmony patches in this folder.
+
+## Notes / gotchas
+
+- Both describer lists (`describers`, `workplaceDescribers`) are `List<IBaseEntityEffectDescriber>` populated via `GetComponents` each time an entity is shown — they are cleared on `ClearFragment`, so there is no stale-reference risk, but it does allocate per-selection.
+- `panel` and `lblEffects` are declared `#nullable disable` because they are initialised in `InitializeFragment` rather than the constructor; callers are expected to call `InitializeFragment` before `ShowFragment`.
+- Default `Order` on both single- and multi-effect interfaces is `0` via explicit interface implementation; the fragment itself uses `-100`, meaning it will appear above most other fragments that do not override their order.

--- a/ModdableTimberborn/EntityTracker/Components/README.md
+++ b/ModdableTimberborn/EntityTracker/Components/README.md
@@ -1,0 +1,28 @@
+# EntityTracker/Components
+
+## Purpose
+
+Decorator components that attach to existing Timberborn entity templates to capture and expose the data each specialised tracker needs at registration time. They run `Awake()` once per entity and then sit as lightweight, pre-resolved property bags.
+
+## Key types
+
+- **`CharacterTrackerComponent`** — decorates `Character` entities. Resolves and caches `CharacterType` (adult beaver / child beaver / bot), a `Worker` reference (nullable — not all characters are workers), and an optional `BonusTrackerComponent`. Exposes convenience bool properties (`IsBot`, `IsBeaver`, `IsAdult`, `IsChild`, `IsWorker`) and `HasBonus(string id)`.
+- **`WorkplaceTrackerComponent`** — decorates `WorkplaceSpec` entities. Caches the `Workplace` component, a `TemplateName` string (from `TemplateSpec`), and the `IsBuilderWorkplace` flag.
+
+## How it fits together
+
+Both components are registered as template decorators in `EntityTrackerConfig` via `BindTemplateModule`. Because they implement `IAwakableComponent`, the engine calls `Awake()` before the entity is fully initialised. By the time `EntityInitializedEvent` fires and `CharacterTracker` / `WorkplaceTracker` call `Track`, the components are already populated.
+
+`CharacterTracker` uses `CharacterTrackerComponent.CharacterType` to route each entity into the correct internal set (adults, children, bots). `WorkplaceTracker` reads `WorkplaceTrackerComponent.Workplace` to wire up worker-assignment events.
+
+## Dependencies & patterns
+
+- `IAwakableComponent` — Timberborn lifecycle hook; `Awake()` is the only lifecycle method used here.
+- `BaseComponent` — Timberborn base for all entity components.
+- `Worker`, `Workplace`, `TemplateSpec`, `CharacterType` — standard Timberborn game types resolved via `GetComponent<T>()`.
+- `BonusTrackerComponent` — from the BonusTracker subsystem of ModdableTimberborn; resolved optionally in `CharacterTrackerComponent`.
+
+## Notes / gotchas
+
+- `WorkplaceTrackerComponent` uses `#nullable disable` for its three properties because they cannot be set in the constructor (set in `Awake`). Consumers should treat them as always-set after entity initialisation.
+- `CharacterTrackerComponent.Worker` is properly nullable (`Worker?`) and guarded by `IsWorker`; bots and children may not have a `Worker` component.

--- a/ModdableTimberborn/EntityTracker/README.md
+++ b/ModdableTimberborn/EntityTracker/README.md
@@ -1,0 +1,44 @@
+# EntityTracker
+
+## Purpose
+
+Maintains live, categorised sets of in-game entities (characters, workplaces, and any mod-registered component type) so that other systems can query "all adults", "all builder workplaces", etc. without walking the full entity list themselves. It hooks into Timberborn's `EntityInitializedEvent` / `EntityDeletedEvent` to keep the sets up to date automatically.
+
+## Key types
+
+- **`IEntityTracker`** — non-generic base interface; exposes `Track(EntityComponent)` and `Untrack(EntityComponent)`. Every tracker must implement this so `EntityTrackerController` can fan out events to all of them.
+- **`IEntityTracker<T>`** — generic extension; adds `Entities: IReadOnlyCollection<T>` and `OnEntityRegistered` / `OnEntityUnregistered` events for typed consumers.
+- **`DefaultEntityTracker<T>`** — generic, sealed implementation of `IEntityTracker<T>`. Used automatically for any component type registered via `ModdableTimberbornRegistry.TryTrack<T>()`. Silently skips entities that don't carry the requested component.
+- **`CharacterTracker`** — specialised tracker for characters. Maintains separate sets for adult beavers, child beavers, and bots, plus convenience enumerables (`Beavers`, `Workers`). Provides `GetCharacters(CharacterType)` and `GetCharacters<T>(CharacterType)` for filtered iteration.
+- **`WorkplaceTracker`** — specialised tracker for workplaces. Adds `BuilderWorkplaces` view and forwards `Workplace.WorkerAssigned` / `WorkerUnassigned` events as `OnWorkerAssigned` / `OnWorkerUnassigned` on the tracker itself.
+- **`EntityTrackerController`** — singleton `ILoadableSingleton`. Registers with the `EventBus` on load and dispatches `EntityInitializedEvent` / `EntityDeletedEvent` to every `IEntityTracker` in the multi-binding.
+- **`EntityTrackerConfig`** — `IModdableTimberbornRegistryConfig` that wires up the DI graph. Also hosts the partial `ModdableTimberbornRegistry` extension that adds `UseEntityTracker()` and `TryTrack<T>()`.
+
+## How it fits together
+
+`EntityTrackerController` is the single listener for entity lifecycle events. On each event it iterates every `IEntityTracker` registered in the multi-binding and calls `Track` or `Untrack`. Each tracker's `Track`/`Untrack` implementation calls `entity.GetComponent<T>()` and no-ops if the component is absent, making the fan-out safe regardless of entity type.
+
+Consumers inject the specific typed tracker they need (e.g. `CharacterTracker`, `WorkplaceTracker`, or `DefaultEntityTracker<MyComp>`) and either iterate `Entities` or subscribe to the registered/unregistered events.
+
+Mod authors opt in via the registry fluent API:
+
+```csharp
+ModdableTimberbornRegistry.Instance
+    .UseEntityTracker()          // activates EntityTrackerConfig
+    .TryTrack<MyComponent>();    // registers DefaultEntityTracker<MyComponent>
+```
+
+`TryTrack<T>` guards against redundantly registering the built-in character/workplace types and throws an `InvalidOperationException` with a helpful message if misused.
+
+## Dependencies & patterns
+
+- **Bindito (DI):** `MultiBind` / `MultiBindAndBindSingleton` for `IEntityTracker`; `BindSingleton` for individual trackers and the controller. Open-generic `DefaultEntityTracker<T>` is registered at runtime via `MakeGenericType`.
+- **Timberborn events:** `EventBus` + `[OnEvent]` attributes on `EntityTrackerController`. Relies on `EntityInitializedEvent` and `EntityDeletedEvent`.
+- **Entity component model:** `EntityComponent`, `BaseComponent`, `IAwakableComponent` from Timberborn's entity system.
+- **Template decoration:** `BindTemplateModule` adds `CharacterTrackerComponent` and `WorkplaceTrackerComponent` as decorators on `Character` and `WorkplaceSpec` prefabs respectively.
+- **Registry pattern:** `EntityTrackerConfig` is a partial class split across the `ModdableTimberborn.EntityTracker` namespace (config impl) and `ModdableTimberborn.Registry` namespace (registry extension), both in the same file.
+
+## Notes / gotchas
+
+- The `#nullable disable` block in `WorkplaceTrackerComponent` suppresses nullability on `Workplace`, `IsBuilderWorkplace`, and `TemplateName` because they are set in `Awake()` rather than the constructor.
+- `CharacterTrackerComponent` carries a reference to `BonusTrackerComponent` (from a different subsystem), making it a small aggregation hub for per-character cross-cutting concerns.

--- a/ModdableTimberborn/GameModes/README.md
+++ b/ModdableTimberborn/GameModes/README.md
@@ -1,0 +1,37 @@
+# GameModes
+
+## Purpose
+
+Provides a thin runtime layer for reading, persisting, and matching the active game mode (difficulty preset) in a ModdableTimberborn save. It captures which `GameModeSpec` was chosen at new-game time, reconstructs what the live game settings actually are mid-save (in case mods changed them), and scores how closely the live state still matches any known preset.
+
+## Key types
+
+- **`GameDifficultyEnum`** — Simple enum (`Custom`, `Easy`, `Medium`, `Hard`) used as a consumer-friendly label when the raw `GameModeSpec.DisplayNameLocKey` needs to be bucketed into a named difficulty tier.
+- **`PersistentGameModeService`** — `[BindSingleton]` service that loads, reconstructs, and saves game-mode state. Implements `ILoadableSingleton` and `ISaveableSingleton`.
+
+## How it fits together
+
+On load, `PersistentGameModeService.Load()` runs two paths:
+
+1. **New game** — reads the chosen `GameModeSpec` directly from `GameSceneParameters.NewGameConfiguration.GameMode` and stores it as both `StartedMode` and `ReconstructedMode`.
+2. **Continue save** — deserialises the originally-chosen mode from the save file (JSON under key `"StartedMode"`), then **reconstructs** what the current mode actually looks like by reading live values from several game services (`NeedModificationService`, `TemperateWeatherDurationService`, `DroughtWeather`, `BadtideWeather`, `EffectProbabilityService`, `GoodRecoveryRateService`).
+
+After reconstruction, `TryMatchMode()` iterates all known `GameModeSpec` objects from `GameModeSpecService.GetSpecsOrdered()`, scores each one by counting how many *recoverable* properties match the reconstructed mode, and exposes `BestMatchedMode` + `MatchScore` (0–1 ratio).
+
+`CheckForModifiedStart()` compares `StartedMode` with `ReconstructedMode` to set `StartedModeModified`, signalling that the live game settings have drifted from what was originally chosen.
+
+The extension method `GameModeSpec.GetDifficultyEnum()` in `Helpers/CommonExtensions.cs` maps the game's localisation key to `GameDifficultyEnum` — this is the primary consumer of that enum.
+
+**Consumer usage:** other subsystems inject `PersistentGameModeService` to check which difficulty the player started on (`StartedMode`), what it looks like now (`ReconstructedMode`), and whether settings have been tampered with (`StartedModeModified`).
+
+## Dependencies & patterns
+
+- **DI:** `[BindSingleton]` (Bindito). No explicit configurator — registration is attribute-driven.
+- **Save/Load:** Timberborn's `ISingletonLoader` / `ISingletonSaver` with a `SingletonKey("PersistentGameModeService")` and a single `PropertyKey<string>("StartedMode")`.
+- **Serialisation:** `JsonConvert` (Newtonsoft.Json) used to serialise/deserialise `GameModeSpec` as JSON. Before saving, `ComponentSpec.Blueprint` is nulled out on `StartedMode` and all its `MinMaxSpec<>` sub-properties to avoid serialising large blueprint references.
+- **Reflection:** `RecoverableProperties` and `MinMaxProperties` are computed once at class-init via `typeof(GameModeSpec).GetProperties(...)` and stored as `static readonly FrozenSet`/`ImmutableArray`. `UnrecoverableProperties` excludes starting population/food/water fields from matching (these can't be "recovered" from a running game).
+- **Timberborn game types used:** `GameModeSpec`, `GameModeSpecService`, `GameSceneParameters`, `NeedModificationService`, `TemperateWeatherDurationService`, `DroughtWeather`, `BadtideWeather`, `EffectProbabilityService`, `GoodRecoveryRateService`, `ComponentSpec`.
+
+## Notes / gotchas
+
+- `GameModeSpecService` and `GameModeSpec` are Timberborn game types — they do not live in this repo. If the game updates their property set, the reflection-based scoring loop silently adapts, but `UnrecoverableProperties` (hardcoded by name) may need manual updates.

--- a/ModdableTimberborn/GameStats/Implementations/README.md
+++ b/ModdableTimberborn/GameStats/Implementations/README.md
@@ -1,0 +1,29 @@
+# GameStats/Implementations
+
+## Purpose
+
+Concrete `IGameStatProvider` implementations that ship with ModdableTimberborn. They expose Timberborn's built-in population and goods data as named stats consumable through `GameStatService`.
+
+## Key types
+
+- **`GlobalPopulationStatsProvider`** (`IIntGameStatProvider`) — wraps `PopulationService.GlobalPopulationData` to expose integer counts for population, beds, workforce (beaver/bot/combined), and contamination. Workforce stat IDs are prefixed with the character-type name (e.g. `"BeaversEmployable"`, `"BotEmployable"`) while unprefixed IDs give the combined total.
+- **`GlobalPopulationPercentStatsProvider`** (`IPercentGameStatProvider`) — wraps the same `GlobalPopulationData` to expose a small set of ratio stats (e.g. `"BeaverPercent"`, `"HomelessPercent"`, `"ContaminatedPercent"`). Formatted output is `"P0"` percentage via the interface default.
+- **`GoodStatsProvider`** (`IIntGameStatProvider`) — iterates `IGoodService.Goods` at query time to expose per-good integer stats: `"GoodAmount.<goodId>"` (available stock) and `"GoodCapacity.<goodId>"` (input/output capacity), delegating to `ResourceCountingService.GetGlobalResourceCount`.
+- **`GoodPercentStatsProvider`** (`IPercentGameStatProvider`) — iterates `IGoodService.Goods` to expose `"GoodFill.<goodId>"` (fill rate as a float 0–1).
+
+## How it fits together
+
+All four classes are auto-discovered and registered by `GameStatsConfig` via assembly reflection — no manual wiring needed. They are injected into `GameStatService` as an `IEnumerable<IGameStatProvider>` and their stat IDs are indexed at load time.
+
+The goods providers use a **prefix + good-ID** naming scheme (`GoodAmount.Wood`, `GoodFill.Water`, etc.). `AvailableStats` is evaluated at registration time (during `GameStatService.Load`), so the set of known good IDs is snapshotted at that point.
+
+## Dependencies & patterns
+
+- **Timberborn services injected via constructor**: `PopulationService`, `IGoodService`, `ResourceCountingService`.
+- Workforce stat IDs for beaver/bot are built with `nameof(CharacterType.Beavers)` / `nameof(CharacterType.Bot)` as prefixes — coupling the stat name to the Timberborn type name.
+- `FrozenSet<string>` used for O(1) category dispatch in `GlobalPopulationStatsProvider`.
+
+## Notes / gotchas
+
+- `GoodStatsProvider` and `GoodPercentStatsProvider` call `IGoodService.Goods` in `AvailableStats` — this is snapshotted at `Load()`. Goods added dynamically after load would not appear.
+- All unrecognised stat IDs throw `ArgumentOutOfRangeException` — consistent with the fail-loud policy.

--- a/ModdableTimberborn/GameStats/README.md
+++ b/ModdableTimberborn/GameStats/README.md
@@ -1,0 +1,37 @@
+# GameStats
+
+## Purpose
+
+Provides a unified, string-keyed lookup service for game-wide statistics (population counts, good amounts, fill rates, etc.). It exists so that other subsystems — e.g. UI, condition checkers, or dynamic text — can query any stat by name without hard-coding calls to Timberborn's individual services. The design is intentionally extensible: new stat providers can be dropped in without touching the core service.
+
+## Key types
+
+- **`IGameStatProvider`** — base interface every stat source implements. Declares `AvailableStats` (string keys it owns), `OutputType`, `GetStat(string)`, and a default `GetStatFormatted(string)`.
+- **`IGameStatProvider<T>`** — generic typed variant; provides `OutputType` automatically and bridges the typed `GetStat` back to the untyped interface.
+- **`IIntGameStatProvider`**, **`IFloatGameStatProvider`**, **`IStringGameStatProvider`**, **`ISpriteGameStatProvider`** — convenience marker interfaces for the four common value types.
+- **`IPercentGameStatProvider`** — specialisation of `IGameStatProvider<float>` that overrides `GetStatFormatted` to render the value as `"P0"` percentage (or `"N/A"` when negative).
+- **`GameStatService`** — singleton that collects all registered `IGameStatProvider`s at load time, indexes them into a `FrozenDictionary<string, IGameStatProvider>` keyed by stat ID, and exposes `GetStat`, `GetStatFormatted`, `TryGetStat<T>`, and `GetProvider`/`GetProvider<T>`.
+- **`GameStatsConfig`** — Bindito configurator; auto-discovers every non-abstract `IGameStatProvider` in the assembly via reflection and multi-binds it, then binds `GameStatService` as a singleton. Also extends `ModdableTimberbornRegistry` with `UseGameStats()`.
+
+## How it fits together
+
+`ModdableTimberbornRegistry.UseGameStats()` is the opt-in entry point — calling it registers `GameStatsConfig` with the DI container. `GameStatsConfig.Configure` scans the assembly for `IGameStatProvider` implementations, multi-binds each one, and binds `GameStatService`. At game load, `GameStatService.Load` aggregates all injected providers into the frozen lookup table; duplicate stat IDs throw immediately to catch registration bugs early.
+
+Consumers call `GameStatService.GetStat("SomeStatId")` (or the typed/formatted overloads) to read any value. Because the lookup is by string key, stats can be referenced from data (JSON/configs) without code dependencies on specific providers.
+
+The `Implementations/` subfolder contains the concrete providers shipped with the library (see its own README).
+
+## Dependencies & patterns
+
+- **Bindito DI**: `[MultiBind]`-style multi-binding done programmatically in `GameStatsConfig`; `ILoadableSingleton` drives `GameStatService.Load`.
+- **`IModdableTimberbornRegistryConfig`**: standard ModdableTimberborn configurator pattern for opt-in feature registration.
+- **`ModdableTimberbornRegistry` partial class**: `UseGameStats()` extends the registry fluent builder.
+- **`FrozenDictionary`** (.NET 8): used for the post-load lookup table — read-only after `Load()`, so freeze is appropriate.
+- No Harmony patches in this folder.
+
+## Notes / gotchas
+
+- Stat ID collisions across providers cause an immediate `Exception` in `Load()` — this is intentional and good, but means any third-party provider must use unique prefixes (see the `GoodAmount.`, `GoodCapacity.`, `GoodFill.` prefix pattern in the built-in providers).
+- `GetStat<T>` and `GetProvider<T>` cast without checking `OutputType`; a mismatch throws `InvalidCastException` at runtime. Use `TryGetStat<T>` when the type is uncertain.
+- `GetStatFormatted` falls back to `ToString()` on the base interface; only `IPercentGameStatProvider` has a custom formatter — other providers would need to override it explicitly.
+- Auto-discovery in `GameStatsConfig` scans `typeof(GameStatsConfig).Assembly` only, so providers defined in other assemblies (mods, etc.) must register themselves separately.

--- a/ModdableTimberborn/Helpers/README.md
+++ b/ModdableTimberborn/Helpers/README.md
@@ -1,0 +1,49 @@
+# Helpers
+
+## Purpose
+
+General-purpose utilities and extension methods used throughout ModdableTimberborn. This folder provides shared enums, extension method groups, a safe-mutation collection, inventory discovery logic, and glue for Harmony patching — avoiding duplication across the feature-specific subsystems.
+
+## Key types
+
+- **`CommonExtensions`** (`partial` class, split across `CommonExtensions.cs`, `CharacterExtensions.cs`, `ConfigurationExtensions.cs`) — the central extension-method hub. Covers numeric helpers (`PercentOf`, `Percent`), localization (`THours`), `NumericComparisonMode` → char conversion, `FrozenDictionary` group-by, reflection-based `SetGetOnlyProperty`, `GameObject.RemoveComponent<T>`, `BaseComponent.GetComponentOrNull<T>`, `BonusType` → `BonusSpec` conversion, `GameModeSpec` → `GameDifficultyEnum`, and `ITimeTriggerFactory.CreateAndStart`.
+- **`ConfigurationExtensions`** (partial of `CommonExtensions`) — extension methods on Bindito's `ConfigurationContext` and `Configurator`. Adds context predicate helpers (`IsGameContext`, `IsGameplayContext`, etc.), a `ToBindAttributeContext` mapper, and typed multi-bind shortcuts for `ITemplateCollectionServiceTailRunner`, `ITemplateModifier`, `ISpecServiceTailRunner`, and `ISpecModifier`.
+- **`CharacterExtensions`** (partial of `CommonExtensions`) — extension methods on `CharacterType` and `BaseComponent`. Includes `IsBot`, `IsBeaver`, `IsWorker`, `GetCharacterType<T>`, `IsBuilder`, `IsBuilderWorkplace`, and accessors for `BonusManager` / `BonusTrackerComponent` / `PersistentBonusTrackerComponent`.
+- **`AutomationExtensions`** — extension methods on `AutomatorConnection`. Three `TryConnecting` overloads that accept a `Guid?`, an `EntityComponent?`, or an `Automator?`, resolving them through `EntityRegistry` where needed.
+- **`EntityExtensions`** — extension methods on `BaseComponent` and `EntityRegistry`. Provides `GetEntityId`, `GetUpdatableStatComponent`, `TryGetEntity`, `DescribeEntity`, and `TryGetAutomator`.
+- **`InventoryFinder`** — static utility for locating an inventory on a `BaseComponent`. Probes a known priority list of inventory-bearing component types (`SimpleOutputInventory`, `Stockpile`, `Manufactory`, `GoodConsumingBuilding`, `WonderInventory`, `BreedingPod`, `FireworkLauncher`, `DistrictCrossingInventory`, `RecoveredGoodStack`) and returns an `InventoryInfo` value struct with the component, `Inventory`, and `InventoryType` flags.
+- **`InventoryInfo`** — `readonly record struct(BaseComponent, Inventory, InventoryType)` returned by `InventoryFinder`.
+- **`InventoryType`** — `[Flags]` enum: `In`, `Out`, `Unlimited`, `Both`.
+- **`CommonEnums`** — shared enums not tied to a single subsystem: `BonusType` (six bonus categories), `ModifierPriority` (`Force`/`Additive`/`Multiplicative` as int ranks), `CharacterType` (`[Flags]`: `Bot`, `AdultBeaver`, `ChildBeaver`, plus composite values `Beavers`, `Workers`, `All`).
+- **`DeferredCollection<TCollection, T>`** — mutation-safe wrapper around any `ICollection<T>`. Queues `Add`, `Remove`, and `Clear` operations issued during enumeration and flushes them when the last `SafeEnumerate` iterator exits. Tracks nesting depth so reentrant enumeration is handled correctly.
+- **`DeferredList<T>` / `DeferredHashSet<T>`** — concrete shorthands over `DeferredCollection` for `List<T>` and `HashSet<T>`.
+- **`PatchExtensions`** — helpers for writing Harmony patches. `PatchAwakePostfix` and `PatchStartPostfix` wire the patched component to its `BaseModdableComponent<TComp>` sibling. `TranspileAndThrowIfNotFound` guards transpiler lambdas: if the target instruction is never matched it throws with a full IL dump rather than silently patching nothing.
+- **`ModdableTimberbornUtils`** — miscellaneous statics. Holds `AllCharacterTypes` array, the mutable `CurrentContext` property (set by configurators to track which Bindito context is active), a `LogVerbose` wrapper prefixing `[ModdableTimberborn]`, and `AddSlotsToPrefab` / `KeepAddingUntil` for blueprint slot manipulation.
+
+## How it fits together
+
+`CommonExtensions` is the largest file and is deliberately `partial` — the character, configuration, and core portions live in separate files but compile to one class. Feature code across ModdableTimberborn imports this namespace and calls the extension methods without any DI injection.
+
+`InventoryFinder` is used by automation and building-interaction subsystems to discover what kind of inventory a building owns without knowing its concrete type upfront. The priority order in `LookForInventories` is significant: `ConstructionSite` is excluded from the general search and must be queried separately via `LookForConstructionSiteInventory`.
+
+`DeferredCollection` is used wherever a collection can be modified by callbacks fired during iteration (e.g., event listener lists, tick subscriber lists). Consumers call `SafeEnumerate()` rather than iterating `Collection` directly.
+
+`PatchExtensions` is called from Harmony postfix and transpiler patch methods. `PatchAwakePostfix` / `PatchStartPostfix` replace boilerplate that would otherwise appear in every Harmony patch class that delegates to a `BaseModdableComponent`.
+
+`ModdableTimberbornUtils.CurrentContext` is written by the configurator infrastructure so that utilities can branch on the active Bindito scene at configuration time.
+
+## Dependencies & patterns
+
+- **Bindito (DI):** `ConfigurationExtensions` wraps `Configurator` multi-bind helpers and `BindAttributes`. `ModdableTimberbornUtils.CurrentContext` tracks the active `ConfigurationContext`.
+- **Harmony:** `PatchExtensions` uses `CodeInstruction`, `StrongBox<bool>`, and IL opcode/operand inspection — a direct Harmony/Cecil dependency.
+- **Timberborn game types:** Heavy use of `BaseComponent`, `EntityRegistry`, `Automator`, inventory types, `BonusManager`, `Worker`, `Workplace`, `Blueprint`, spec types, and `ILoc` localization — all Timberborn game assembly references.
+- **Unity:** `GameObject`, `Object.Destroy`/`DestroyImmediate`, and `Debug.LogWarning` appear in `CommonExtensions` and `ModdableTimberbornUtils`.
+- **C# extension syntax (C# 14 `extension` blocks):** The codebase uses the new `extension(Type t) { ... }` syntax preview feature rather than classic `this`-parameter extension methods. This is visible in `AutomationExtensions`, `CommonExtensions`, `EntityExtensions`, etc.
+- **Immutable collections:** `ImmutableArray`, `FrozenDictionary` used in extension helpers and `ModdableTimberbornUtils`.
+- No DI registrations live in this folder — these are pure utilities consumed by higher-level configurators elsewhere.
+
+## Notes / gotchas
+
+- **`ModdableTimberbornUtils.CurrentContext` is `internal set`:** It is written by the configurator layer and read by helpers. Bindito configuration runs single-threaded, so this is safe in normal usage.
+- **`CharacterType.ArrayLength`** is defined as `HighestBit + 1 = 5`, which equals the numeric value of `ChildBeaver` (4) plus 1. This is intended for array indexing by flag value but is only meaningful if flag values stay contiguous powers of two.
+- The `extension(...)` syntax is C# 14 preview; this requires an appropriate `<LangVersion>` in the project file and may not be widely familiar to contributors.

--- a/ModdableTimberborn/MechanicalSystem/Patches/README.md
+++ b/ModdableTimberborn/MechanicalSystem/Patches/README.md
@@ -1,0 +1,25 @@
+# MechanicalSystem/Patches
+
+## Purpose
+
+Contains all Harmony patches for the `MechanicalSystem` subsystem. These patches hook into vanilla `MechanicalNode` and `MechanicalGraph` to inject the modding layer and fix edge-case vanilla bugs exposed when power values become dynamic.
+
+## Key Types
+
+- **`MechanicalNodePatches`** — Static patch class targeting `MechanicalNode`. Hooks `Awake` (postfix) to initialise the `ModdableMechanicalNode` decorator, and patches `CanPotentiallyBePowered` (prefix) to return `true` for nodes whose nominal input is zero or below.
+- **`MechanicalGraphPatches`** — Patch class targeting `MechanicalGraph`. Adds a postfix to the `Powered` getter so that a graph with zero `PowerDemand` reports itself as powered (vanilla returns `false` in this case).
+
+## How It Fits Together
+
+Both classes share the Harmony category `ModdableTimberborn.MechanicalSystem` (from `ModdableMechanicalSystemConfig.PatchCategoryName`). They are activated as a unit when `UseMechanicalSystem()` is called on the registry, and can be deactivated together by un-applying that category.
+
+`MechanicalNodePatches.AwakePostfix` delegates to the framework helper `PatchAwakePostfix<MechanicalNode, ModdableMechanicalNode>()`, which locates the decorator on the same GameObject, sets `OriginalComponent`, and calls `AwakeAfter()` — bootstrapping the modifier pipeline for that node.
+
+## Dependencies & Patterns
+
+- **Harmony** — `[HarmonyPatchCategory]`, `[HarmonyPatch]`, `[HarmonyPostfix]`, `[HarmonyPrefix]` attributes; standard Harmony 2.x conventions.
+- No DI or Bindito involvement; patches operate directly on vanilla component instances.
+
+## Notes / Gotchas
+
+- The zero-demand `Powered` fix in `MechanicalGraphPatches` is a global behaviour change for all mechanical graphs, not scoped to moddable nodes. This could affect vanilla UI (e.g., power-supply indicators on empty networks).

--- a/ModdableTimberborn/MechanicalSystem/README.md
+++ b/ModdableTimberborn/MechanicalSystem/README.md
@@ -1,0 +1,36 @@
+# MechanicalSystem
+
+## Purpose
+
+Wraps Timberborn's `MechanicalNode` component in ModdableTimberborn's modifier pipeline so that a node's nominal power input and output can be altered at runtime by registered modifiers. Without this subsystem, a building's power values are fixed at prefab-load time and cannot be changed by mods.
+
+## Key Types
+
+- **`ModdableMechanicalNode`** — Decorator component (`BaseModdableComponent<MechanicalNode>`) attached alongside every `MechanicalNode`. Owns a `MechanicalNodeModifierCollection`, reacts to dirty notifications, and pushes recalculated values back into the wrapped node via `UpdatePowerInput()` / `UpdatePowerOutput()`. Raises `OnMechanicalNodeValuesChanged` after each recalculation.
+- **`MechanicalNodeValues`** — Immutable `readonly record struct` holding the two values that can be modified: `NominalInput` and `NominalOutput`.
+- **`ModdableMechanicalNodeValues`** — Thin `ModdableValue<MechanicalNodeValues>` wrapper; passed into each modifier in the chain and carries the current (mutable) and original values.
+- **`IModdableMechanicalNodeModifier`** — Marker interface extending `IModdableModifier<ModdableMechanicalNodeValues, MechanicalNodeValues>`. Mod code implements this to supply power modifiers.
+- **`ModdableMechanicalSystemConfig`** — `IModdableTimberbornRegistryWithPatchConfig` singleton that registers the Harmony patch category and binds `ModdableMechanicalNode` as a template decorator for `MechanicalNode` via Bindito's `BindTemplateModule`.
+
+## How It Fits Together
+
+At game startup, `ModdableTimberbornRegistry.UseMechanicalSystem()` (a partial method on the shared registry) registers `ModdableMechanicalSystemConfig.Instance` as a configurator. The configurator adds `ModdableMechanicalNode` as a decorator on every `MechanicalNode` prefab in the game context.
+
+`MechanicalNodePatches` hooks `MechanicalNode.Awake` with a postfix that calls `PatchAwakePostfix<MechanicalNode, ModdableMechanicalNode>()` — a framework helper that sets `OriginalComponent` on the decorator and then calls `AwakeAfter()`. Inside `AwakeAfter`, the decorator reads the node's current `_nominalPowerInput`/`_nominalPowerOutput` to seed `MechanicalNodeValues`, and wires up a `MechanicalNodeModifierCollection` whose `OnDirty` triggers `UpdateValues()`.
+
+When any registered `IModdableMechanicalNodeModifier` fires `OnChanged`, the collection marks itself dirty. The next call to `UpdateValues()` runs the full modifier chain, compares old/new values, and (if changed) writes back into the original component and fires `OnMechanicalNodeValuesChanged` for any downstream listeners.
+
+Consumers (mod features) add modifier instances to the component's collection and listen to `OnMechanicalNodeValuesChanged` for UI or logic updates.
+
+## Dependencies & Patterns
+
+- **Harmony** — Two patch classes under `Patches/`, grouped under the category `ModdableTimberborn.MechanicalSystem`. Patches are applied/removed as a unit via that category name.
+- **Bindito (DI)** — `BindTemplateModule` + `AddDecorator` attaches `ModdableMechanicalNode` to Timberborn's prefab template system; no `[MultiBind]` attributes are used here directly.
+- **Common framework** — Inherits `BaseModdableComponent<T>`, `ModdableValue<T>`, `IModdableModifier<,>`, and the implicit `ModifierCollection` / `ValueModifierCollection` infrastructure from `ModdableTimberborn.Common`.
+- **Registry pattern** — `ModdableTimberbornRegistry.UseMechanicalSystem()` is a fluent opt-in method (idempotent guard via `MechanicalSystemUsed`), consistent with all other subsystems in this library.
+
+## Notes / Gotchas
+
+- `MechanicalGraphPatches.PowerIsSuppliedWhenZeroConsumption` fixes a vanilla edge case: a `MechanicalGraph` with zero demand is not considered `Powered` by default. This patch forces `Powered = true` when `PowerDemand == 0`, which is a behaviour change affecting all mechanical networks (not just moddable ones) once the category is enabled.
+- `MechanicalNodePatches.PatchWhenZeroUsage` patches `MechanicalNode.CanPotentiallyBePowered` to return `true` for nodes with zero nominal input, bypassing the vanilla `NoPowerStatus` check. Both patches alter base game behaviour and may interact with other mods that touch power logic.
+- There is no persistence (save/load) of modified values; modifiers are expected to re-apply themselves on load.

--- a/ModdableTimberborn/OptionalMods/README.md
+++ b/ModdableTimberborn/OptionalMods/README.md
@@ -1,0 +1,35 @@
+# OptionalMods
+
+## Purpose
+
+Provides a mechanism for a mod to ship DLLs that are only loaded at runtime when a specific *other* mod is also enabled. This avoids hard compile-time dependencies between mods: the optional DLL sits dormant unless its required companion mod is present, preventing load errors when that companion is absent.
+
+## Key types
+
+- **`OptionalModsLoader`** — Static utility that scans every enabled mod's directory for files matching the naming convention `*.dll.<targetModId>.optional`, loads them via `Assembly.Load`, and then walks their exported types to find and invoke `IModStarter` implementations.
+- **`OptionalModStarter`** — The `IModStarter` entry point for this subsystem itself. Applies Harmony patches in the `ModdableTimberborn.OptionalMods` category on startup.
+- **`OptionalModPatches`** — Harmony patch class (prefix on `ModAssetBundleLoader.Load`) that triggers `OptionalModsLoader.Load` at the right moment in Timberborn's mod-loading pipeline, but only when the call originates from `ModManagerScenePanel` to avoid double-invocation.
+
+## How it fits together
+
+`OptionalModStarter` is registered as a normal `IModStarter` entry point for ModdableTimberborn itself. When Timberborn initialises the mod, `OptionalModStarter.StartMod` runs Harmony, which patches `ModAssetBundleLoader.Load`.
+
+When that patched method fires (from the Mod Manager scene), `OptionalModPatches.LoadOptionalMods` calls `OptionalModsLoader.Load(modRepository)`. The loader then:
+
+1. Builds a set of all currently-enabled mod IDs.
+2. For each enabled mod, finds any files named `*.dll.<modId>.optional` in the mod's directory tree.
+3. Loads each file as an `Assembly` only if `<modId>` is in the enabled set.
+4. For every loaded assembly, reflects over its types looking for concrete `IModStarter` implementations and instantiates + runs them via `starter.StartMod(ModEnvironment.Create(mod))`.
+
+Consumers (other mods using ModdableTimberborn) do not interact with this subsystem directly; they simply name their optional DLL according to the convention and implement `IModStarter` inside it.
+
+## Dependencies & patterns
+
+- **Harmony** — `OptionalModStarter` applies a prefix patch on `ModAssetBundleLoader.Load`; the patch category is `ModdableTimberborn.OptionalMods`.
+- **Timberborn internals** — `ModRepository`, `ModAssetBundleLoader`, `ModManagerScenePanel`, `Mod`, `IModStarter`, `ModEnvironment`, `IModEnvironment` (Timberborn's own mod API).
+- **`TimberUiUtils.LogVerbose`** — Used for opt-in verbose tracing during load; not conditional-compiled, just behind a verbosity flag.
+- No Bindito/DI registration — the loader is invoked purely through the Harmony patch, not via the DI container.
+
+## Notes / gotchas
+
+- **File naming is order-sensitive** — `GetModId` strips the `.optional` suffix, then reads everything after the first occurrence of `.dll.`. Name optional DLL files with a single `.dll.` segment before the mod ID to avoid ambiguity.

--- a/ModdableTimberborn/Patches/README.md
+++ b/ModdableTimberborn/Patches/README.md
@@ -1,0 +1,26 @@
+# Patches
+
+## Purpose
+
+Contains Harmony postfix patches that hook into Timberborn's internal infrastructure at points where the game's own code runs but mod code has no direct access. Currently the sole concern is intercepting DI container creation so ModdableTimberborn can hold a live reference to the Bindito `IContainer` for later imperative service resolution.
+
+## Key types
+
+- **`ContainerRetrieverPatches`** — Static Harmony patch class. Postfixes `ContainerCreator.CreateContainer` to capture the freshly-built `IContainer` and hand it to `ContainerRetriever`.
+
+## How it fits together
+
+When Timberborn bootstraps a scene it calls `ContainerCreator.CreateContainer`, which builds and returns a Bindito `IContainer`. The `[HarmonyPostfix]` on that method fires immediately after, receiving `__result` (the new container), and passes it straight to `new ContainerRetriever(__result)` in `ModdableTimberborn.Services`. `ContainerRetriever` stores the container behind a `WeakReference` so it doesn't prevent GC if the scene unloads, and exposes static `GetInstance<T>()` / `GetInstances<T>()` helpers that the rest of ModdableTimberborn uses to resolve services imperatively (i.e., outside normal constructor injection).
+
+The Patches folder is therefore the sole bridge between Timberborn's container lifecycle and ModdableTimberborn's service-resolution utilities. No other code in ModdableTimberborn needs to know how the container was obtained.
+
+## Dependencies & patterns
+
+- **Harmony** — `[HarmonyPatch]` / `[HarmonyPostfix]` attributes; the class must be picked up by a `Harmony.PatchAll()` call somewhere in the mod's entry point.
+- **Bindito** — `IContainer` is the Bindito DI container interface native to Timberborn mods.
+- **`ContainerCreator`** (Timberborn internal) — the patched type; lives outside this repo.
+- No Bindito configurator or `[MultiBind]` registration is used here — the patch is self-contained and activates purely via Harmony attribute scanning.
+
+## Notes / gotchas
+
+- There is only one file in this folder; it is intentionally minimal — all logic lives in `ContainerRetriever` (Services folder), not here.

--- a/ModdableTimberborn/README.md
+++ b/ModdableTimberborn/README.md
@@ -1,0 +1,68 @@
+# ModdableTimberborn
+
+## Purpose
+
+ModdableTimberborn (mod id `ModdableTimberborn`, version 10.7.0) is a shared modding-support library for Timberborn (minimum game version 1.0.5). It exposes APIs — entity stats, bonus systems, mechanical system hooks, serialization helpers, and more — that other mods depend on rather than re-implementing. Consuming mods reference the DLL and call `ModdableTimberbornRegistry.Instance.AddConfigurator<T>()` at startup to register their own Bindito bindings and Harmony patches.
+
+## Entry Points / Lifecycle
+
+### `MStarter : IModStarter`
+The Timberborn mod loader calls `IModStarter.StartMod(IModEnvironment)` once at boot. The implementation just calls `ModdableTimberbornRegistry.Instance.ConfigureStarter()`, which re-applies `harmony.PatchAllUncategorized()`. (Harmony is also initialised in the `ModdableTimberbornRegistry` static constructor, so patches that are categorised fire earlier via `PatchAllUncategorized` in the constructor itself.)
+
+### `MConfigs.cs` — four `Configurator` classes
+One class per Bindito DI context (`Bootstrapper`, `MainMenu`, `Game`, `MapEditor`). Each is decorated with `[Context("...")]` so Timberborn's DI wiring discovers them automatically. All four simply delegate to `ModdableTimberbornRegistry.Instance.Configure(this, context)`, which iterates the registered `IModdableTimberbornRegistryConfig` objects that opted into that context and calls `Configure(configurator, context)` on each.
+
+### `ModdableTimberbornConfigurator : IModdableTimberbornRegistryConfig`
+The library's own default DI configurator. It opts into `Game | MapEditor` (i.e., `ConfigurationContext.NonMenu`) and calls `configurator.BindAttributes(context)`, which wires all attribute-annotated types discovered in those contexts. Registered as a default by the registry alongside `ModdableEntityDescriberConfigurator`.
+
+### `ModdableTimberbornRegistry` (in `Registry/`)
+A static singleton. Manages two collections: a flat set of all registered `IModdableTimberbornRegistryConfig` objects and a per-context list for fast dispatch. On `AddConfigurator`, if the config also implements `IModdableTimberbornRegistryWithPatchConfig`, its Harmony patches are applied immediately (either by category or by whole assembly). The four `MConfig` classes call `Configure(configurator, context)` during Bindito scene setup; `ConfigureStarter()` is called once by `MStarter`.
+
+### Harmony integration
+A single `Harmony` instance named `"ModdableTimberborn"` is created in the static constructor. It immediately calls `PatchAllUncategorized()`. Categorised patches are applied lazily when a configurator that owns them is added; uncategorized patches are applied at both construction and `ConfigureStarter`.
+
+## Build / Project Notes
+
+- **Target framework:** `netstandard2.1`, `LangVersion: preview`, nullable enabled.
+- **Version conditionality:** The shared `Common.targets` supports two Timberborn release streams: `version-0.7` (U7, `TIMBER7` constant) and `version-1.0` (V1, `TIMBERV1` constant). Files under `V1\` / `*.V1.cs` or `U7\` / `*.U7.cs` are compiled selectively. Currently set to `version-1.0`.
+- **Publicized game assemblies:** `GameAssemblyPublicizer\out\common\**\*.dll` — `AllowUnsafeBlocks` is required for the `IgnoresAccessChecks` trick that bypasses member-visibility enforcement at runtime.
+- **Harmony:** referenced from the Steam Workshop mod folder (`3284904751\0Harmony.dll`), declared as a `RequiredMods` entry in the manifest.
+- **TimberUi:** referenced from `GameModsFolder\TimberUi\version-1.0\**\*.dll`, also a `RequiredMods` dependency (minimum 10.1.5).
+- **Bindito:** pulled in via the publicized game assemblies (no separate NuGet package).
+- **ModAnalyzers:** a source generator / Roslyn analyzer from the game solution; currently the project reference is commented out and the pre-built `.dll` is used directly.
+- **Internals visible to** `ModdableTimberborn.Tests`.
+- **Post-build copy:** `Common.targets` copies the output DLL, `manifest.json`, localization files, assets, etc. straight into `GameModsFolder\ModdableTimberborn\version-1.0\` — no separate deployment step needed.
+
+## Subsystems (Table of Contents)
+
+Each subsystem has its own README under `.notes/ModdableTimberborn/<FolderName>/README.md`.
+
+- **Areas** — geographic/zone area definitions and helpers used by other subsystems.
+- **BonusSystem** — generic value-bonus/modifier pipeline; provides typed modifier collections consumed by mechanical, entity-stat, and other systems.
+- **BuildingSettings** — exposes per-building configurable settings (UI and data) so mods can add settings panels to buildings.
+- **Common** — shared primitives: `ValueModifierCollection`, utility extension methods, and base types used across the whole library.
+- **CompatWeatherService** — compatibility shim / wrapper around the game's weather/drought service for cross-version safety.
+- **DependencyInjection** — Bindito DI helpers: attribute scanning, configurator base classes, and `BindAttributes` extension that drives automatic binding.
+- **EnterableSystem** — hooks into the game's enterable-building system so mods can intercept or extend enter/exit logic.
+- **EntityDescribers** — the `IModdableEntityDescriber` pattern; lets mods attach descriptor fragments to entities without subclassing game types.
+- **EntityTracker** — generic entity-tracking service; maintains live collections of entities matching a given predicate or type, used by other subsystems for efficient queries.
+- **GameModes** — abstractions for game mode detection (e.g., sandbox vs. campaign), used to gate behaviour per mode.
+- **GameStats** — global game-level statistics tracking (resources produced, buildings placed, etc.) exposed for mod consumption.
+- **Helpers** — miscellaneous utility classes and extension methods that don't belong to a specific subsystem.
+- **Localizations** — helpers for registering and resolving localization keys from mod-supplied `.txt`/`.po` files.
+- **MechanicalSystem** — moddable wrappers around Timberborn's mechanical-power network: power producers, consumers, and the `MechanicalNodeModifierCollection` alias defined in `zGlobalUsings.cs`.
+- **OptionalMods** — infrastructure for declaring soft/optional dependencies on other mods; loads integration code only when a target mod is present.
+- **Patches** — Harmony patch classes that apply game-level fixes or hooks needed by the library itself (not by individual subsystems).
+- **Registry** — core registry infrastructure: `ModdableTimberbornRegistry` singleton, `ConfigurationContext` flags enum, `IModdableTimberbornRegistryConfig` interface, and base configurator classes.
+- **SerializationSystem** — helpers for serializing/deserializing custom mod data with Timberborn's save/load pipeline.
+- **Services** — general-purpose service base classes and interfaces (e.g., tick listeners, singleton service helpers).
+- **SoakEffect** — support for the game's water-soak effect on entities; allows mods to attach soak-related modifiers or reactions.
+- **UpdatableEntityStats** — per-entity stat values that update each tick; integrates with `BonusSystem` so modifiers are applied automatically. See also the dedicated sub-tree note.
+- **WorkSystem** — moddable extensions to the worker/work-place system: work speed, efficiency modifiers, and related hooks.
+
+## Notes / Gotchas
+
+- **`zGlobalUsings.cs`** is prefixed with `z` so it sorts last in editors; it contains one non-trivial line — a `global using` alias for `MechanicalNodeModifierCollection` that parameterises the generic `ValueModifierCollection` with the mechanical-node types. If that alias is missing from the compilation the whole `MechanicalSystem` subsystem breaks.
+- **`ModdableTimberbornRegistry` is a static singleton initialised at class-load time.** Consuming mods must call `AddConfigurator` in their own `IModStarter.StartMod`, before Bindito scenes are constructed.
+- **The `ModPath` and `AssemblyPath` in `CommonProperties.targets` are machine-local paths** that must be overridden when building on a different machine (typically via a `Directory.Build.props` or a local override targets file not tracked in git).
+- **`workshop_data.json` is present** alongside `manifest.json`; it is copied one level above the mod folder (i.e., next to the mod directory, not inside it) — this is how the Timberborn mod uploader expects it.

--- a/ModdableTimberborn/README.md
+++ b/ModdableTimberborn/README.md
@@ -35,7 +35,7 @@ A single `Harmony` instance named `"ModdableTimberborn"` is created in the stati
 
 ## Subsystems (Table of Contents)
 
-Each subsystem has its own README under `.notes/ModdableTimberborn/<FolderName>/README.md`.
+Each subsystem has its own README under `ModdableTimberborn/<FolderName>/README.md`.
 
 - **Areas** — geographic/zone area definitions and helpers used by other subsystems.
 - **BonusSystem** — generic value-bonus/modifier pipeline; provides typed modifier collections consumed by mechanical, entity-stat, and other systems.

--- a/ModdableTimberborn/Registry/README.md
+++ b/ModdableTimberborn/Registry/README.md
@@ -1,0 +1,39 @@
+# Registry
+
+## Purpose
+
+This subsystem is the central DI configurator hub for ModdableTimberborn. It maintains a singleton registry of all mod configurators, routes Bindito `Configurator.Configure()` calls to the right registered configs based on game lifecycle context (Bootstrapper / MainMenu / Game / MapEditor), and triggers Harmony patching when a config with patches is registered.
+
+## Key Types
+
+- **`ModdableTimberbornRegistry`** (partial singleton) — the core registry. Holds all `IModdableTimberbornRegistryConfig` instances, dispatches `Configure()` calls per context, and delegates Harmony patching. The partial class is extended in `DependencyInjection/ModdableDependencyInjectionConfig.cs` to add opt-in DI support.
+- **`ConfigurationContext`** (`[Flags]` enum) — the four lifecycle contexts (`Bootstrapper`, `MainMenu`, `Game`, `MapEditor`) plus convenience combos (`All`, `None`, `NonMenu`). Used to gate which configurators run in which scene.
+- **`IModdableTimberbornRegistryConfig`** — the base interface every configurator must implement. Declares `AvailableContexts` (defaults to `All`) and `Configure(Configurator, ConfigurationContext)`.
+- **`IModdableTimberbornRegistryWithPatchConfig`** — extends the base interface for configurators that also need Harmony patching. `PatchCategory` selects a named category; `null` patches the whole assembly.
+- **`IWithDIConfig`** — marker interface; implementing it on a config class automatically activates the ModdableTimberborn DI subsystem (calls `InternalUseDependencyInjection()`).
+- **`BaseModdableTimberbornConfiguration`** — abstract base for mod entry-point configs. Implements `IModStarter`; `StartMod` registers `this` with the registry and optionally enables DI if the subclass also implements `IWithDIConfig`.
+- **`BaseModdableTimberbornConfigurationWithHarmony`** — extends the above for configs that also patch. Overridable `PatchCategory` (defaults to `null` → patch whole assembly).
+- **`BaseModdableTimberbornAttributeConfiguration`** — convenience base that implements `Configure()` by calling `configurator.BindAttributes(context, assembly, defaultScope)`, so subclasses only need to declare `AvailableContexts` and optionally override `Assembly` / `DefaultScope`.
+
+## How It Fits Together
+
+`ModdableTimberbornRegistry.Instance` is a static singleton created at class-initialisation time. The four Bindito configurator classes in `MConfigs.cs` (`ModBootstrapperConfig`, `ModMainMenuConfig`, `ModGameConfig`, `ModMapEditorConfig`) are annotated with Timberborn's `[Context(...)]` attribute; Timberborn calls `Configure()` on each at the appropriate game lifecycle stage, which simply delegates to `ModdableTimberbornRegistry.Instance.Configure(this, <context>)`.
+
+Mods plug in by subclassing `BaseModdableTimberbornConfiguration` (or one of its variants) and implementing `IModStarter`. When Timberborn calls `StartMod`, the base class registers the config instance with the registry. From that point on, whenever the matching context fires, the registry calls `config.Configure(configurator, context)` and the mod's DI bindings are applied.
+
+Harmony patching is also driven through the registry: `AddConfigurator` checks whether the config implements `IModdableTimberbornRegistryWithPatchConfig` and, if so, calls either `harmony.PatchCategory(category)` or `harmony.PatchAll(assembly)` immediately upon registration. Uncategorized patches are applied at startup via `MStarter` → `ConfigureStarter()` → `harmony.PatchAllUncategorized()`.
+
+`ModdableTimberbornUtils.CurrentContext` is updated by the registry just before each dispatch loop so other code can read the active context at runtime.
+
+## Dependencies & Patterns
+
+- **Bindito (DI):** All `Configure` methods receive a Bindito `Configurator`. Context mapping uses `ConfigurationContext.ToBindAttributeContext()` (extension in `Helpers/ConfigurationExtensions.cs`) to bridge to Bindito's `BindAttributeContext`.
+- **Harmony:** A single `Harmony` instance named `"ModdableTimberborn"` is held on `ModdableTimberbornRegistry`. Patching is idempotent per category via `PatchedCategories` — a category is only patched once even if multiple configurators share it.
+- **`IModStarter`:** Timberborn's mod entry-point hook. `BaseModdableTimberbornConfiguration` implements it so mods self-register without needing to know about `MConfigs.cs`.
+- **DI opt-in pattern:** Implementing `IWithDIConfig` on a config class (no members required) triggers `InternalUseDependencyInjection()`, which registers `ModdableDependencyInjectionConfig` — a guard (`DependencyInjectionUsed` flag) ensures it is only added once. The `UseDependencyInjection()` fluent method exists but is marked `[Obsolete]`.
+
+## Notes / Gotchas
+
+- `ModdableTimberbornRegistry` is `partial`; the DI-related members (`DependencyInjectionUsed`, `InternalUseDependencyInjection`, `UseDependencyInjection`) live in `DependencyInjection/ModdableDependencyInjectionConfig.cs`, not in the `Registry/` folder. Searching for the full class requires looking outside this folder.
+- `AddDefaultConfigurators()` always registers `ModdableEntityDescriberConfigurator` and `ModdableTimberbornConfigurator` at construction time; there is no way to opt out.
+- `IWithDIConfig` has no members — it is purely a marker interface. Implementing it on a config class activates the ModdableTimberborn DI subsystem; omitting it leaves the DI subsystem inactive for that config.

--- a/ModdableTimberborn/SerializationSystem/README.md
+++ b/ModdableTimberborn/SerializationSystem/README.md
@@ -1,0 +1,32 @@
+# SerializationSystem
+
+## Purpose
+
+Provides JSON serialization and deserialization support for Timberborn's `SerializedObject` type using Newtonsoft.Json. This folder exists because Timberborn's own `SerializedObject` is a structured property-bag that doesn't map cleanly to standard JSON converters, so a custom converter and convenience extension methods are needed to bridge the two.
+
+## Key types
+
+- **`SerializedObjectJsonConverter`** (`ModdableTimberborn.SerializationSystem`) — A singleton `JsonConverter<SerializedObject>` that handles recursive read/write between `SerializedObject` trees and raw JSON. Supports nested objects, arrays, and the primitive types int, float, bool, string, and null. Throws on unsupported token types (no silent failure).
+- **`ModdableTimberbornSerializationExtensions`** (`Timberborn.SerializationSystem`) — A static class (using C# extension method syntax) that surfaces three convenience helpers: `DeserializeSerializedObject(string json)` (static), `SerializeToJson()` (on `SerializedObject`), and `DeserializeTo<T>()` (round-trips a `SerializedObject` through JSON into any target type `T`).
+
+## How it fits together
+
+`SerializedObjectJsonConverter` is a singleton wired into a shared `JsonSerializerSettings` instance held by `ModdableTimberbornSerializationExtensions`. All three public helpers use those same settings, so the converter is always active. The typical consumer flow is:
+
+1. Receive or construct a `SerializedObject` from Timberborn's serialization pipeline.
+2. Call `.SerializeToJson()` to get a plain JSON string (e.g. for persistence, logging, or inter-mod data exchange).
+3. Call `DeserializeSerializedObject(json)` to reconstruct from a stored string, or `.DeserializeTo<T>()` to map directly into a strongly-typed C# object.
+
+`DeserializeTo<T>()` works by first serializing the `SerializedObject` back to JSON, then deserializing into `T` — a two-pass round-trip that lets callers use standard Newtonsoft deserialization without hand-coding property lookups.
+
+## Dependencies & patterns
+
+- **Newtonsoft.Json** (`JsonConvert`, `JsonConverter<T>`, `JToken`/`JProperty`) — the only external dependency in this folder.
+- **Timberborn game assemblies** — `SerializedObject` and its `Properties()` / `GetSerialized()` API are from the game, not defined here.
+- No DI registration, no Harmony patches, no Unity dependencies in this folder.
+- The two files sit in different namespaces on purpose: the converter lives in `ModdableTimberborn.SerializationSystem` (mod-owned), while the extensions live in `Timberborn.SerializationSystem` (game namespace) so they appear alongside the type they extend without requiring a `using` statement at the call site.
+
+## Notes / gotchas
+
+- `DeserializeTo<T>()` performs a serialize-then-deserialize round-trip, which doubles JSON processing. Callers passing custom `JsonSerializerSettings` to `DeserializeTo<T>()` should be aware that those settings do **not** include `SerializedObjectJsonConverter` — only the outer call chain uses it.
+- The `extension(SerializedObject obj)` syntax in `ModdableTimberbornSerializedObjectExtensions.cs` is the C# 13 "extension member" preview feature, not classic `this` extension methods. Requires a compiler/SDK that supports it.

--- a/ModdableTimberborn/Services/README.md
+++ b/ModdableTimberborn/Services/README.md
@@ -1,0 +1,41 @@
+# Services
+
+## Purpose
+
+A small collection of cross-cutting singleton services that sit outside any single feature area. They provide globally accessible infrastructure — DI container introspection, in-game day-relative timing, and coordinated terrain/block-object destruction — that other subsystems consume directly.
+
+## Key Types
+
+- **`ContainerRetriever`** — Static-access shim over the Bindito `IContainer`. Stores the container in a `WeakReference` so it goes away when the scene unloads. Exposes `GetInstance<T>()` / `GetInstances<T>()` as static helpers for places where normal constructor injection is not possible.
+- **`DayTimerService`** — `[BindSingleton]` that lets callers schedule an `Action` to fire at a specific in-game hour offset after each day starts (repeating) or once on the next day. Returns a `DayTimerReference` token used for unregistration.
+- **`DayTimerReference`** — Lightweight `record` carrying the delay, action, and repeat flag; used as the unregistration handle.
+- **`DestructionService`** — `[BindSingleton(Contexts = BindAttributeContext.NonMenu)]` that handles the full lifecycle of block-object/terrain destruction: querying the affected set (including physics-dependent objects above terrain), highlighting in the UI, and executing deletion.
+- **`DestroyingEntities`** — Immutable `readonly record struct` bundling `ImmutableArray<BlockObject>` and `ImmutableArray<Vector3Int>` returned by a destruction query; passed between the query, highlight, and destroy steps.
+
+## How It Fits Together
+
+`ContainerRetriever` is registered alongside the main DI configuration (presumably in a configurator elsewhere); it self-registers its static `instance` field on construction, making it available to Harmony patches or static factory methods that cannot receive injected dependencies normally. The `Refresh()` method cleans up the stale reference after scene teardown.
+
+`DayTimerService` listens on the `EventBus` for `CycleDayStartedEvent`. On each new day it iterates every registered delay bucket and fires an `ITimeTriggerFactory`-created timer for each, so actions execute at the correct fractional-day offset rather than immediately. Callers call `Register` / `RegisterOnce`, hold the returned `DayTimerReference`, and call `Unregister` when the owning component is torn down.
+
+`DestructionService` provides a two-phase API: **query** (returns a `DestroyingEntities` snapshot) → optional **highlight** (feeds `RollingHighlighter` and `TerrainHighlightingService`) → **destroy** (delegates to `EntityService.Delete` and `TerrainDestroyer.DestroyTerrain`). Callers are expected to call `UnhighlightDestructionEntities` when the operation is cancelled. The service reuses two internal `HashSet` scratch collections, clearing them after each `ReturnQuery()` call — it is not thread-safe.
+
+## Dependencies & Patterns
+
+| Type | Source |
+|---|---|
+| `IContainer`, `[BindSingleton]`, `[MultiBind]` | Bindito (Timberborn DI) |
+| `ILoadableSingleton` | Timberborn lifecycle interface |
+| `EventBus`, `[OnEvent]`, `CycleDayStartedEvent` | Timberborn event system |
+| `ITimeTriggerFactory` | Timberborn timing infrastructure |
+| `ITerrainPhysicsService`, `TerrainDestroyer`, `IBlockService` | Timberborn terrain/block layer |
+| `EntityService` | Timberborn entity management |
+| `TerrainHighlightingService`, `RollingHighlighter` | Timberborn UI highlight layer |
+| `ISpecService`, `BrushColorSpec` | Timberborn spec/config system |
+
+`DestructionService` uses `BindAttributeContext.NonMenu` to exclude it from the main-menu scene container.
+
+## Notes / Gotchas
+
+- `ContainerRetriever.Instance` is a **mutable static singleton** — the last constructed instance wins. This works because Timberborn constructs a fresh DI container per scene, but be aware in tests or multi-container scenarios.
+- `DayTimerService` snapshots `timers.Keys.ToArray()` before iterating, so registrations made from inside a timer callback during the same `OnNewDay` event are safely deferred to the following day.

--- a/ModdableTimberborn/SoakEffect/README.md
+++ b/ModdableTimberborn/SoakEffect/README.md
@@ -1,0 +1,36 @@
+# SoakEffect
+
+## Purpose
+
+Provides per-tick water-exposure tracking for every `Character` in the game. Each tick, the component checks whether the character's grid coordinate is submerged, fires events so other components can react (e.g. apply damage, contamination effects), and maintains a simple in/out state flag. It exists to give mod components a single, efficient subscription point for water contact rather than each one querying the water map independently.
+
+## Key types
+
+- **`ModdableSoakEffectComponent`** — `TickableComponent` / `IAwakableComponent` decorator added to every `Character`. Queries `ThreadSafeWaterMap` each tick, fires `OnSoakedTick` while submerged and `IsInWaterStateChanged` when the in-water state changes. Respects any `IWaterResistor` siblings on the same entity.
+- **`SoakEffectEventArgs`** — Readonly record struct passed with `OnSoakedTick`. Carries `Resistant` flag, the raw `ReadOnlyWaterColumn` (depth, contamination, floor), the character's `Vector3Int` grid coordinate, a pre-computed `WaterCeiling` (water surface z), and `PassedTimeInHours` from `IDayNightCycle`.
+- **`ModdableSoakEffectConfig`** — Singleton `IModdableTimberbornRegistryConfig`. Binds `ModdableSoakEffectComponent` as a template-module decorator on `Character` when running in a Game context.
+- **`ModdableTimberbornRegistry.UseSoakEffect()`** (partial, defined here) — Opt-in registration method; guards against double-registration via `SoakEffectUsed` flag.
+
+## How it fits together
+
+Activation is opt-in: a mod calls `registry.UseSoakEffect()` during its configuration phase (e.g. `BeavVsMachine`'s `MConfigs.cs`). This registers `ModdableSoakEffectConfig`, which uses Bindito's template-module system to inject `ModdableSoakEffectComponent` as a decorator on every `Character` prefab.
+
+At runtime, `Awake()` collects all `IWaterResistor` sibling components so resistance checks are cheap per-tick. Each `Tick()`, `UpdateState()` converts the character's world position to a grid coordinate, samples the water column, computes whether the character is actually submerged (water ceiling >= character z), and returns a `SoakEffectEventArgs` if so.
+
+Consumers subscribe to `OnSoakedTick` on the `ModdableSoakEffectComponent` they fetch via `GetComponentFast<>()`. The `BotWaterDamageComponent` in `BeavVsMachine` is the primary consumer: it scales durability loss by `PassedTimeInHours` and the column's `Contamination` value.
+
+`IsInWaterStateChanged` is available for state-transition logic (e.g. entering/leaving water effects) but has no subscribers in the current codebase.
+
+## Dependencies & patterns
+
+- **Bindito DI:** `[Inject]` on `Inject(IThreadSafeWaterMap, IDayNightCycle)`. Registered as a template-module decorator (`AddDecorator<Character, ModdableSoakEffectComponent>()`), so the DI container instantiates one per character prefab.
+- **Timberborn engine types:** `ThreadSafeWaterMap` / `IThreadSafeWaterMap`, `ReadOnlyWaterColumn`, `NavigationCoordinateSystem`, `IDayNightCycle`, `TickableComponent`, `IAwakableComponent`, `Character`, `IWaterResistor`.
+- **Unity:** `Mathf.CeilToInt`, `Vector3Int`, `Transform.position`.
+- **No Harmony patches.** Pure Bindito decorator injection.
+- **`IWaterResistor`** — interface expected to be on sibling components; no implementation found in this folder (must be provided by Timberborn core or another mod component).
+
+## Notes / gotchas
+
+- `IWaterResistor` has no definition inside this repo's `SoakEffect` folder; it is a Timberborn core interface provided by the engine.
+- `IsInWaterStateChanged` fires on every state flip, including re-entering water after a brief gap, so subscribers should not assume it fires only once per submersion event.
+- `IsInWater` reflects unresisted water exposure: it is `false` when the character is water-resistant, even if physically submerged.

--- a/ModdableTimberborn/UpdatableEntityStats/Implementations/README.md
+++ b/ModdableTimberborn/UpdatableEntityStats/Implementations/README.md
@@ -1,0 +1,48 @@
+# UpdatableEntityStats/Implementations
+
+## Purpose
+
+Contains the concrete `IUpdatableEntityStat` factory classes and their paired `StatTrackerBase<T>` tracker subclasses for all built-in stat types. Each pair follows the same pattern: a singleton factory that checks feasibility and constructs a tracker, plus a tracker that subscribes to game component events and calls `UpdateValue()` on each change.
+
+## Key types
+
+### Base classes (re-exported from this namespace)
+
+- **`StatTrackerBase<T>`** — Abstract base for all entity-bound trackers. Handles `Start`/`Pause` lifecycle, value diffing, event firing, and self-registration with `UpdatableEntityStatComponent`. Subclasses implement `OnStart()`, `OnPause()`, and `CalculateValue()`.
+- **`StatPercentTrackerBase`** — `StatTrackerBase<float>` that also implements `IPercentStatTracker`; formats `ValueFormatted` as `"P0"`.
+- **`UpdatableEntityStatBase<T>`** — Abstract base for stat factories. Provides the default `DisplayLoc` convention (`"LV.MT.UStat.<Id>"`).
+- **`ComponentUpdatableEntityStatBase<T, TComp>`** — Stat factory that gates on the presence of a Timberborn `BaseComponent` of type `TComp`. Subclasses only implement `GetComponentTracker(statComp, comp)`.
+- **`ComponentUpdatableEntityPercentStatBase<TComp>`** — Extends the above for percent stats (`float`), threading through both `IPercentStat` and `IEntityPercentStatTracker`.
+
+### Concrete stat pairs
+
+| Stat class | Tracker class | Id | Value type | Driven by |
+|---|---|---|---|---|
+| `NameStat` | `NameTracker` | `"Name"` | `string` | `NamedEntity.EntityNameChanged` |
+| `AvatarStat` | `AvatarStatTracker` | `"Avatar"` | `Sprite?` | `Contaminable.ContaminationChanged` |
+| `ProductionPercentStat` | `ProductionPercentStatTracker` | `"ProductionPercent"` | `float` | `Manufactory.ProductionProgressed` |
+| `RecipeIconStat` | `RecipeIconStatTracker` | `"RecipeIcon"` | `Sprite?` | `Manufactory.RecipeChanged` |
+| `InventoryStockStat` | `InventoryStatTracker<int>` | `"StorageStock"` | `int` | `Inventory.InventoryChanged` |
+| `InventoryStockMax` | `InventoryStatTracker<int>` | `"StorageStockMax"` | `int` | `Inventory.InventoryChanged` |
+| `InventoryPercent` | `InventoryPercentStatTracker` | `"StoragePercent"` | `float` | `Inventory.InventoryChanged` |
+| `StockpileIconStat` | `StockpileIconStatTracker` | `"StockpileIcon"` | `Sprite?` | `SingleGoodAllower.DisallowedGoodsChanged` |
+| `PopulationStat` | `DistrictPopulationStatTracker` / `GlobalPopulationStatTracker` | `"Population"` | `int` | `PopulationStatService.OnPopulationChanged` |
+
+## How it fits together
+
+All concrete stat classes in this folder are picked up automatically by the reflection loop in `UpdatableEntityStatsConfig` and multi-bound as `IUpdatableEntityStat` singletons. `UpdatableEntityStatService` aggregates them.
+
+`InventoryStat<T>` is a shared intermediate base for the three inventory stats; it uses `InventoryFinder.LookForInventories` to locate the relevant `Inventory` component and then delegates tracker creation to subclasses. `InventoryStatTracker<T>` is the generic tracker that accepts a `Func<Inventory, T>` value extractor.
+
+`AvatarStat` is slightly special: `CanTrack` delegates to `EntityBadgeService` rather than checking for a specific component, but the tracker is always created (returns `true`) for any non-null entity — avatar display is considered universally available.
+
+`PopulationStat` lives at the root namespace level (not in `Implementations/`) because it is directly exposed through `UpdatableEntityStatService.PopulationStat`; it also provides a `GetGlobalTracker(options)` factory method for non-entity-bound global population tracking.
+
+## Dependencies & patterns
+
+- All concrete stats and trackers depend solely on Timberborn game components; no Harmony patches are used here.
+- Tracker construction is always side-effectful: the `StatTrackerBase<T>` constructor calls `comp.AddTracker(this)`, so a tracker is live the moment it is created. Callers must either call `Start()` promptly or `Dispose()` the tracker if they decide not to use it.
+
+## Notes / gotchas
+
+- **`InventoryStatTracker<T>`** is not abstract and is used directly by `InventoryStockStat` and `InventoryStockMax` via a lambda; `InventoryPercent` subclasses it as `InventoryPercentStatTracker` to override `ValueFormatted`.

--- a/ModdableTimberborn/UpdatableEntityStats/Implementations/README.md
+++ b/ModdableTimberborn/UpdatableEntityStats/Implementations/README.md
@@ -6,7 +6,7 @@ Contains the concrete `IUpdatableEntityStat` factory classes and their paired `S
 
 ## Key types
 
-### Base classes (re-exported from this namespace)
+### Base classes (in `ModdableTimberborn.UpdatableEntityStats`)
 
 - **`StatTrackerBase<T>`** — Abstract base for all entity-bound trackers. Handles `Start`/`Pause` lifecycle, value diffing, event firing, and self-registration with `UpdatableEntityStatComponent`. Subclasses implement `OnStart()`, `OnPause()`, and `CalculateValue()`.
 - **`StatPercentTrackerBase`** — `StatTrackerBase<float>` that also implements `IPercentStatTracker`; formats `ValueFormatted` as `"P0"`.
@@ -36,7 +36,7 @@ All concrete stat classes in this folder are picked up automatically by the refl
 
 `AvatarStat` is slightly special: `CanTrack` delegates to `EntityBadgeService` rather than checking for a specific component, but the tracker is always created (returns `true`) for any non-null entity — avatar display is considered universally available.
 
-`PopulationStat` lives at the root namespace level (not in `Implementations/`) because it is directly exposed through `UpdatableEntityStatService.PopulationStat`; it also provides a `GetGlobalTracker(options)` factory method for non-entity-bound global population tracking.
+`PopulationStat` is in the root namespace (`ModdableTimberborn.UpdatableEntityStats`) because it is directly exposed through `UpdatableEntityStatService.PopulationStat`; it also provides a `GetGlobalTracker(options)` factory method for non-entity-bound global population tracking.
 
 ## Dependencies & patterns
 

--- a/ModdableTimberborn/UpdatableEntityStats/README.md
+++ b/ModdableTimberborn/UpdatableEntityStats/README.md
@@ -1,0 +1,43 @@
+# UpdatableEntityStats
+
+## Purpose
+
+Provides a framework for attaching observable, pausable stat trackers to Timberborn game entities. Consumers (e.g. UI widgets) ask a stat object to produce a tracker for a specific entity; the tracker pushes `OnValueChanged` events whenever the underlying game state changes, and can be paused/resumed to avoid subscriptions while off-screen. This decouples UI update logic from the specifics of each game component.
+
+## Key types
+
+- **`IUpdatableEntityStat` / `IUpdatableEntityStat<T>`** — Factory interface. Each stat has a string `Id`, a localization key `DisplayLoc`, and the ability to answer `CanTrack(comp)` and produce a typed `IEntityStatTracker` for a given entity component.
+- **`IStatTracker` / `IStatTracker<T>`** — Lifecycle interface for a live tracker: `Start()`, `Pause()`, `Running`, `Value`, `ValueFormatted`, `OnValueChanged`, `OnTypedValueChanged`.
+- **`IEntityStatTracker` / `IEntityStatTracker<T>`** — Extends `IStatTracker` with the owning `UpdatableEntityStatComponent` and an `OnEntityLost` event fired when the entity is deleted.
+- **`IPercentStat` / `IPercentStatTracker` / `IEntityPercentStatTracker`** — Marker interfaces for `float` stats that display as a percentage (`"P0"` format). `IPercentStatTracker` provides a default `ValueFormatted` implementation.
+- **`IImageStat` / `IImageStatTracker`** — Marker interfaces for `Sprite?` stats (entity avatars, recipe icons, stockpile icons).
+- **`UpdatableEntityStatComponent`** — `BaseComponent` / `IDeletableEntity` attached to every entity via the template module. Owns the set of live trackers; on `DeleteEntity()` it calls `NotifyEntityLost()` on each then disposes them all.
+- **`UpdatableEntityStatService`** — Singleton registry of all `IUpdatableEntityStat` instances (injected as a multi-bind collection). Exposes typed filtered arrays (`AllImageStats`, `AllPercentStats`) and a by-`Id` lookup. Also surfaces the `PopulationStat` directly.
+- **`PopulationStatService`** — Singleton that wraps `SamplingPopulationService` and the game `EventBus`, converting `PopulationChangedEvent` into a simple `OnPopulationChanged` action. Used by population trackers to avoid each tracker subscribing to the event bus independently.
+- **`UpdatableEntityStatsConfig`** — `IModdableTimberbornRegistryConfig`; the DI configurator. Registers services, attaches `UpdatableEntityStatComponent` to all `TemplateSpec`s, and auto-discovers every concrete `IUpdatableEntityStat` in the assembly via reflection for multi-bind registration.
+
+## How it fits together
+
+`UpdatableEntityStatsConfig` is activated by calling `registry.UseUpdatableEntityStats()` during mod bootstrap. It scans the executing assembly for all concrete `IUpdatableEntityStat` implementations and multi-binds them, so `UpdatableEntityStatService` receives the complete collection at injection time.
+
+At runtime, a consumer (typically a UI panel) holds a reference to `UpdatableEntityStatService`. When the player focuses an entity, the consumer calls `stat.TryGetTracker(entityStatComp, out tracker)` for each stat it cares about. The returned tracker is independent per entity—its constructor registers it with the `UpdatableEntityStatComponent`—so `DeleteEntity()` can sweep them all when the entity is removed.
+
+The consumer calls `tracker.Start()` to begin receiving events and `tracker.Pause()` or `tracker.Dispose()` when the panel closes. `ForceUpdating()` triggers an unconditional re-raise of change events regardless of whether the value actually changed (useful for first-display initialization).
+
+`StatTrackerBase<T>` (in `Implementations/`) provides the standard template: `OnStart()`/`OnPause()` subscribe/unsubscribe from underlying game events; `CalculateValue()` computes the new value; `UpdateValue()` compares to the previous value and fires events if changed.
+
+## Dependencies & patterns
+
+- **Bindito (DI):** `MultiBind<IUpdatableEntityStat>` via reflection in `UpdatableEntityStatsConfig`; services registered as singletons. Entry point: `ModdableTimberbornRegistry.UseUpdatableEntityStats()`.
+- **Timberborn `BaseComponent` / template system:** `UpdatableEntityStatComponent` is added as a decorator on `TemplateSpec` so every entity has it automatically.
+- **Timberborn `IDeletableEntity`:** Drives the entity-lost notification path.
+- **Timberborn `EventBus`:** Used only in `PopulationStatService` to receive `PopulationChangedEvent`; other trackers subscribe directly to component-level C# events.
+- **Timberborn game components used by built-in stats:** `DistrictCenter`, `Manufactory`, `Inventory`, `Stockpile` / `SingleGoodAllower`, `NamedEntity`, `Contaminable`, `EntityBadgeService`, `IGoodService`, `SamplingPopulationService`.
+- **Localization key convention:** `DisplayLoc` defaults to `"LV.MT.UStat.<Id>"`.
+
+## Notes / gotchas
+
+- **`PopulationStat.TryGetTracker(options, comp, out tracker)`** mutates the tracker's `Options` after construction (via `internal set`). If `TryGetTracker` is called again for the same entity, it overwrites the options on the existing tracker rather than creating a new one — callers must be aware of tracker identity.
+- **`GlobalPopulationStatTracker`** is not an `IEntityStatTracker`; it does not attach to any `UpdatableEntityStatComponent` and must be disposed manually by the caller.
+- **Auto-discovery via reflection** in `UpdatableEntityStatsConfig` means adding a new stat class is zero-config, but it also means any concrete `IUpdatableEntityStat` in the assembly (including test helpers) will be registered if the config runs.
+- **`InventoryFinder.LookForInventories`** is called by inventory stats but is defined elsewhere in ModdableTimberborn; its semantics (which inventory it picks when multiple exist) are not visible here.

--- a/ModdableTimberborn/WorkSystem/README.md
+++ b/ModdableTimberborn/WorkSystem/README.md
@@ -1,0 +1,43 @@
+# WorkSystem
+
+## Purpose
+
+Provides togglable effect/bonus components scoped to a `Workplace` and its assigned `Worker`s. When the component is active, bonuses (or arbitrary effects) are applied to workers as they are assigned and removed when they are unassigned. Mirrors the EnterableSystem pattern, but targets the work-assignment relationship rather than physical building entry.
+
+## Key types
+
+- **`TogglableWorkplaceEffectComponent`** — Abstract `BaseEventTogglableContainerComponent` subclass (one step above the bonus layer). Subclasses override `OnWorkerAssigned(Worker)` and `OnWorkerUnassigned(Worker)` to apply any arbitrary effect. The `CreateData` override wires a `WorkplaceTogglableContainer` against the sibling `Workplace` component.
+- **`TogglableWorkplaceBonusComponent`** — Concrete-but-abstract subclass of `TogglableWorkplaceEffectComponent`. Subclasses only need to supply a `BonusTrackerItem Bonuses` property; `OnWorkerAssigned`/`OnWorkerUnassigned` are implemented here to call `worker.GetBonusTracker().AddOrUpdate(Bonuses)` and `.Remove(Bonuses.Id)`.
+- **`WorkplaceTogglableContainer`** — Plain C# class (no Unity dependency) extending `BaseEventTogglableContainer<Workplace, Worker>`. Treats `Workplace.AssignedWorkers` as the member enumerable; subscribes to `Workplace.WorkerAssigned` / `WorkerUnassigned` events to call `OnMemberAdded`/`OnMemberRemoved`, which delegate to the constructor-injected `onWorkerAssigned`/`onWorkerUnassigned` action callbacks.
+
+## How it fits together
+
+The three-layer inheritance chain runs:
+
+```
+BaseEventTogglableContainerComponent  (Common — Unity component shell)
+  └─ TogglableWorkplaceEffectComponent  (WorkSystem — Workplace/Worker wiring)
+       └─ TogglableWorkplaceBonusComponent  (WorkSystem — BonusTracker integration)
+            └─ [mod-specific concrete class]
+```
+
+`Awake` on `BaseEventTogglableContainerComponent` calls `CreateData`, which constructs a `WorkplaceTogglableContainer` backed by the co-located `Workplace` component. The container is dormant until `Toggle(true)` is called. On activation, `BaseEventTogglableContainer.PerformActivate` hooks the `WorkerAssigned`/`WorkerUnassigned` events and immediately fires `OnMemberAdded` for every already-assigned worker, so bonuses are applied retroactively. Deactivation mirrors this: event handlers are removed and `OnMemberRemoved` is called for current members.
+
+For the bonus variant, mod authors subclass `TogglableWorkplaceBonusComponent`, return a `BonusTrackerItem` from `Bonuses`, and attach the resulting component to any building prefab that has a `Workplace`. The building also needs a mechanism to call `Toggle(true/false)` — typically a building-settings component or a game-event listener.
+
+**EnterableSystem parallel:** `EnterableSystem/TogglableEnterableBonusComponent` is structurally identical, but uses `Enterable`/`Enterer` instead of `Workplace`/`Worker`. The two subsystems are independent; there is no shared base between them.
+
+## Dependencies & patterns
+
+- **Timberborn game types:** `Workplace`, `Worker`, `WorkerChangedEventArgs` (Timberborn's work-assignment API); `BaseComponent` (Unity wrapper).
+- **BonusSystem:** `BonusTrackerItem`, `worker.GetBonusTracker()` (extension method from BonusSystem). `TogglableWorkplaceBonusComponent` requires `ModdableTimberbornRegistry.UseBonusTracker(bool)` to be called at mod startup so that `BonusTrackerComponent` is decorated onto `Worker` entities. Without this, `GetBonusTracker()` will fail at runtime.
+- **Common abstractions:** `BaseEventTogglableContainerComponent`, `BaseEventTogglableContainer`, `ITogglableContainer` (all from `ModdableTimberborn.Common`).
+- **No DI registration in this folder.** WorkSystem defines only abstract/base component types; concrete subclasses are registered by the consuming mod's configurator. No `[MultiBind]`, no Bindito configurator, no Harmony patches.
+- **No serialization.** Toggle state is not persisted here; if a mod needs toggle state to survive save/load it must handle that itself.
+
+## Notes / gotchas
+
+- `TogglableWorkplaceBonusComponent` requires `ModdableTimberbornRegistry.UseBonusTracker(bool)` to be called at mod startup. If that call is missing, `GetBonusTracker()` will throw a missing-component error at the first worker assignment.
+- There is no DI-based or attribute-based auto-registration for these types. A mod that wants to apply the same bonus to all workplaces must enumerate entities itself (e.g., via `WorkplaceTracker` from EntityTracker) and call `Toggle` manually, or wire up a building-settings toggle.
+- The folder contains only one file (`TogglableWorkplaceBonusComponent.cs`), which defines all three types. The naming of the file omits the `Effect` variant (`TogglableWorkplaceEffectComponent`) — the file name reflects the most-used concrete layer, not the full contents.
+- The `WorkplaceTogglableContainer` does not unsubscribe from `Workplace` events if the containing `GameObject` is destroyed without going through `Toggle(false)` first. Consumers should ensure deactivation before destruction to avoid stale event handlers.


### PR DESCRIPTION
Adds a `README.md` to each subsystem folder of **ModdableTimberborn** (plus a project overview at the library root). Each describes the folder's purpose, its key public types, how the pieces fit together, and notable dependencies/patterns — intended as a navigation aid for contributors working in the library.

30 READMEs covering: Areas, BonusSystem, BuildingSettings (+ BuiltInSettings), Common, CompatWeatherService, DependencyInjection (+ Patches/Specs/TemplateCollection), EnterableSystem, EntityDescribers, EntityTracker (+ Components), GameModes, GameStats (+ Implementations), Helpers, MechanicalSystem (+ Patches), OptionalMods, Patches, Registry, SerializationSystem, Services, SoakEffect, UpdatableEntityStats (+ Implementations), and WorkSystem.

This is independent of the consumer-guides PR — feel free to take either, both, or neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)