### PR TITLE
Add TimberUi consumer documentation

### DIFF
--- a/Docs/README.MD
+++ b/Docs/README.MD
@@ -3,6 +3,7 @@
 Documentations for various Moddable projects.
 
 - [Moddable Timberborn](./ModdableTimberborn#README)
+- [TimberUi](./TimberUi#README)
 - [Moddable Tool Groups](./ModdableToolGroups#README)
 - [Moddable Recipes](./ModdableRecipes#README)
 - [Moddable Decal Groups](./ModdableDecalGroups.MD)

--- a/Docs/TimberUi/AlertsAndBars.MD
+++ b/Docs/TimberUi/AlertsAndBars.MD
@@ -1,0 +1,303 @@
+# Alerts and Bars
+
+Timberborn surfaces three complementary UI slots that mods commonly extend: the **alert panel** (dismissible notification rows above the HUD), the **bottom bar** (tool/shortcut buttons at the screen edge), and the **top bar** (HUD icon buttons). TimberUi provides thin providers and helper types for all three, so you can focus on your logic instead of Bindito boilerplate.
+
+---
+
+## 1. Bottom-bar modules
+
+The bottom bar is assembled from `BottomBarModule` instances, each contributed by an `IProvider<BottomBarModule>`. `BottomBarModuleProvider<T>` is TimberUi's ready-made provider: it takes your element class, adds it to the **right section** of the bar, and returns the built module.
+
+### Implement `IBottomBarElementsProvider`
+
+Timberborn's `IBottomBarElementsProvider` is the contract for a bottom-bar element. The easiest starting point is extending `GrouplessBottomBarButton`, which implements the interface and handles sprite loading, click wiring, and the label displayed beneath the button icon:
+
+```cs
+using TimberUiDemo.UI;
+
+public class DevModeButton : GrouplessBottomBarButton
+{
+    readonly DevModeManager _devMode;
+
+    public DevModeButton(VisualElementLoader veLoader, IAssetLoader assetLoader, DevModeManager devMode)
+        : base(veLoader, assetLoader)
+    {
+        SpritePath   = "Sprites/my-mod-icon";
+        Click        = Toggle;
+        BottomText   = "Dev Mode";
+
+        _devMode = devMode;
+    }
+
+    void Toggle()
+    {
+        if (_devMode.Enabled) _devMode.Disable();
+        else                  _devMode.Enable();
+    }
+}
+```
+
+`GrouplessBottomBarButton` is a Timberborn base class; it requires `VisualElementLoader` and `IAssetLoader` injected through the constructor. Set `SpritePath`, `Click`, and `BottomText` before the panel is first shown.
+
+You can also implement `IBottomBarElementsProvider` directly if you need full control over the visual tree.
+
+### Register with `BottomBarModuleProvider<T>`
+
+In your `[Context("Game")]` configurator, bind your element as a singleton and multibind its provider:
+
+```cs
+[Context("Game")]
+public class GameConfigs : Configurator
+{
+    public override void Configure()
+    {
+        Bind<DevModeButton>().AsSingleton();
+        MultiBind<BottomBarModule>().ToProvider<BottomBarModuleProvider<DevModeButton>>().AsSingleton();
+    }
+}
+```
+
+`BottomBarModuleProvider<T>` is resolved by the container and receives the already-bound `T` instance via constructor injection. It calls `builder.AddRightSectionElement(btn)` internally, so your element always lands in the right section of the bar.
+
+> **Placement.** `BottomBarModuleProvider` always adds elements to the right section. If your mod needs a left-section element, use Timberborn's `BottomBarModule.Builder` directly and multibind your own `IProvider<BottomBarModule>`.
+
+---
+
+## 2. Alert-panel fragments
+
+The alert panel is a vertical stack of dismissible notification rows. Each row is contributed by an `IProvider<AlertPanelModule>`. To add a row you need two things: a fragment class that implements `IAlertFragmentWithOrder`, and a registration call that wires it up.
+
+### Implement `IAlertFragmentWithOrder`
+
+`IAlertFragmentWithOrder` extends Timberborn's `IAlertFragment` with a single `int Order` property used to sort rows within the panel:
+
+```cs
+using TimberUi.CommonUi;
+
+public class LowFoodAlert : IAlertFragmentWithOrder
+{
+    readonly FoodService       _food;
+    readonly AlertPanelRowFactory _rowFactory;
+
+    ClosableAlertElement _row = null!;
+
+    public int Order => 10;   // higher = lower in the panel; use 0 for neutral position
+
+    public LowFoodAlert(FoodService food, AlertPanelRowFactory rowFactory)
+    {
+        _food       = food;
+        _rowFactory = rowFactory;
+    }
+
+    // Timberborn calls InitializeAlertFragment once at startup.
+    public void InitializeAlertFragment(VisualElement parent)
+    {
+        _row = parent.AddClosableAlert(
+            factory:           _rowFactory,
+            iconName:          "FoodWarning",
+            text:              "Food supply is low",
+            buttonAction:      () => { /* navigate to stockpile */ },
+            closeButtonAction: () => _row.Visible = false);
+    }
+
+    // Timberborn calls UpdateAlertFragment periodically, to let you refresh state.
+    public void UpdateAlertFragment()
+    {
+        _row.Visible = _food.IsLow;
+    }
+}
+```
+
+The `Order` value controls sort position relative to other registered fragments: lower numbers appear higher in the panel. Assign distinct values if you need a guaranteed sequence.
+
+### Register with `BindAlertFragment<T>()`
+
+`BindAlertFragment<T>()` is a one-call configurator extension that binds your fragment as a singleton and multibinds `AlertFragmentProvider<T>` into `AlertPanelModule`:
+
+```cs
+[Context("Game")]
+public class GameConfigs : Configurator
+{
+    public override void Configure()
+    {
+        this.BindAlertFragment<LowFoodAlert>();
+    }
+}
+```
+
+Under the hood this is equivalent to:
+
+```cs
+BindSingleton<LowFoodAlert>();
+MultiBind<AlertPanelModule>().ToProvider<AlertFragmentProvider<LowFoodAlert>>().AsSingleton();
+```
+
+`AlertFragmentProvider<T>` calls `builder.AddAlertFragment(fragment, fragment.Order)` on `Get()`, so the `Order` property on your class is the only configuration needed.
+
+---
+
+## 3. `ClosableAlertElement`
+
+`ClosableAlertElement` wraps a Timberborn closable alert row: a main `Button` the player can click to act on the alert, plus a separate `Close` button to dismiss it. It is built from `AlertPanelRowFactory.CreateClosable(iconName)` and exposes a fluent configuration surface.
+
+### Build with `AddClosableAlert`
+
+The `AddClosableAlert` extension method on `VisualElement` is the recommended way to create and attach the element. It calls the constructor, applies optional text and callbacks, names the root, and calls `parent.Add(el.Root)` — all in one step:
+
+```cs
+_row = parent.AddClosableAlert(
+    factory:           _rowFactory,      // inject AlertPanelRowFactory
+    iconName:          "WaterWarning",
+    text:              "Reservoir nearly empty",
+    buttonAction:      NavigateToReservoir,
+    closeButtonAction: () => _row.Visible = false);
+```
+
+`AddClosableAlert` returns the `ClosableAlertElement` so you can store it and update it later.
+
+### API surface
+
+| Member | Type | Description |
+|---|---|---|
+| `Root` | `VisualElement` | The actual element added to the hierarchy. Add this to a parent when constructing manually. |
+| `Button` | `Button` | The main action button (left side of the row in the default game template; actual position depends on the game's alert-row layout). |
+| `CloseButton` | `Button` | The dismiss button (right side of the row in the default game template; actual position depends on the game's alert-row layout). |
+| `Visible` | `bool` | Shows/hides the row via `display` style. Default: `true` after construction. |
+| `SetText(string)` | fluent | Sets `Button.text`. |
+| `SetButtonCallback(Action)` | fluent | Registers a `ClickEvent` callback on `Button`. |
+| `AddCloseCallback(Action)` | fluent | Registers a `ClickEvent` callback on `CloseButton`. |
+| `SetButtonAsCloseCallback()` | fluent | Makes the main button also hide the row (`Visible = false`). |
+
+> **`Root` is not a `VisualElement` itself.** `ClosableAlertElement` is a plain class that holds a `Root` property. If you construct it manually with `new ClosableAlertElement(factory, iconName)`, you must call `parent.Add(el.Root)` explicitly. `AddClosableAlert` does this for you.
+
+### Manual construction
+
+If you prefer to construct the element without the extension method:
+
+```cs
+_row = new ClosableAlertElement(_rowFactory, "FoodWarning");
+_row.SetText("Food supply is low")
+    .SetButtonCallback(NavigateToStockpile)
+    .AddCloseCallback(() => _row.Visible = false);
+
+parent.Add(_row.Root);   // <-- required: add Root, not the element itself
+```
+
+---
+
+## 4. Top-bar buttons
+
+`TopBarButton` is a `NineSliceButton` subclass styled for the game's top bar. It adds a single `Background` property that swaps the button's CSS class between green and brown nine-slice backgrounds.
+
+### Create a `TopBarButton`
+
+`TopBarButton` is a `VisualElement` and can be created with `new` or added via `AddChild<TopBarButton>()`:
+
+```cs
+var btn = parent.AddChild<TopBarButton>();
+btn.text       = "My Tool";
+btn.Background = TopBarButtonBackground.Green;
+btn.RegisterCallback<ClickEvent>(_ => OnClick());
+```
+
+### Background values
+
+| `TopBarButtonBackground` | CSS class applied | Appearance |
+|---|---|---|
+| `Green` | `square-large--green` | Green nine-slice button |
+| `Brown` | `square-large--brown` | Brown nine-slice button |
+
+Setting `Background` removes the previous class and adds the new one, so it is safe to change at runtime (for example, to reflect active/inactive state).
+
+> **Assign `Background` at least once after construction.** The backing field defaults to `Green`, but the `square-large--*` CSS class is not applied until the setter runs. If you never set `Background`, no background class will be present on the element.
+
+---
+
+## 5. Complete example
+
+The following connects all three features: a bottom-bar toggle button, an alert fragment that shows when a condition is active, and a `ClosableAlertElement` as the alert row.
+
+```cs
+// LowFoodAlert.cs
+using TimberUi.CommonUi;
+
+public class LowFoodAlert : IAlertFragmentWithOrder
+{
+    readonly FoodService          _food;
+    readonly AlertPanelRowFactory _rowFactory;
+
+    ClosableAlertElement _row = null!;
+
+    public int Order => 10;
+
+    public LowFoodAlert(FoodService food, AlertPanelRowFactory rowFactory)
+    {
+        _food       = food;
+        _rowFactory = rowFactory;
+    }
+
+    public void InitializeAlertFragment(VisualElement parent)
+    {
+        _row = parent.AddClosableAlert(
+            factory:           _rowFactory,
+            iconName:          "FoodWarning",
+            text:              "Food supply is low",
+            buttonAction:      null,
+            closeButtonAction: () => _row.Visible = false);
+    }
+
+    public void UpdateAlertFragment()
+    {
+        _row.Visible = _food.IsLow;
+    }
+}
+
+// MyToolButton.cs
+public class MyToolButton : GrouplessBottomBarButton
+{
+    public MyToolButton(VisualElementLoader veLoader, IAssetLoader assetLoader)
+        : base(veLoader, assetLoader)
+    {
+        SpritePath = "Sprites/my-tool";
+        Click      = OnClick;
+        BottomText = "My Tool";
+    }
+
+    void OnClick() { /* open tool panel */ }
+}
+
+// ModConfigs.cs
+[Context("Game")]
+public class GameConfigs : Configurator
+{
+    public override void Configure()
+    {
+        this.BindAlertFragment<LowFoodAlert>();
+
+        Bind<MyToolButton>().AsSingleton();
+        MultiBind<BottomBarModule>().ToProvider<BottomBarModuleProvider<MyToolButton>>().AsSingleton();
+    }
+}
+```
+
+---
+
+## Key types
+
+| Type | Role | Source |
+|---|---|---|
+| `IAlertFragmentWithOrder` | `IAlertFragment` + `int Order`; implement on your alert class. | [`../../TimberUi/TimberUi/CommonUi/IAlertFragmentWithOrder.cs`](../../TimberUi/TimberUi/CommonUi/IAlertFragmentWithOrder.cs) |
+| `AlertFragmentProvider<T>` | `IProvider<AlertPanelModule>`; adds `T` to the panel at `T.Order`. | [`../../TimberUi/TimberUi/CommonProviders/AlertFragmentProvider.cs`](../../TimberUi/TimberUi/CommonProviders/AlertFragmentProvider.cs) |
+| `BindAlertFragment<T>()` | Configurator extension: bind singleton + multibind provider, one call. | [`../../TimberUi/TimberUi/Extensions/Configurators.cs`](../../TimberUi/TimberUi/Extensions/Configurators.cs) |
+| `ClosableAlertElement` | Alert row wrapper: main `Button`, `CloseButton`, `Visible`, `SetText`, `SetButtonCallback`, `AddCloseCallback`. | [`../../TimberUi/TimberUi/CommonUi/ClosableAlertElement.cs`](../../TimberUi/TimberUi/CommonUi/ClosableAlertElement.cs) |
+| `AddClosableAlert(...)` | `VisualElement` extension: constructs, configures, and adds `ClosableAlertElement.Root` in one step. | [`../../TimberUi/TimberUi/Extensions/Buttons.cs`](../../TimberUi/TimberUi/Extensions/Buttons.cs) |
+| `BottomBarModuleProvider<T>` | `IProvider<BottomBarModule>`; adds `T` to the right section of the bottom bar. | [`../../TimberUi/TimberUi/CommonProviders/BottomBarModuleProvider.cs`](../../TimberUi/TimberUi/CommonProviders/BottomBarModuleProvider.cs) |
+| `TopBarButton` | `NineSliceButton` with a swappable `Background` (Green/Brown). | [`../../TimberUi/TimberUi/CommonUi/TopBarButton.cs`](../../TimberUi/TimberUi/CommonUi/TopBarButton.cs) |
+| `TopBarButtonBackground` | Enum: `Green` / `Brown`. | [`../../TimberUi/TimberUi/CommonUi/TopBarButton.cs`](../../TimberUi/TimberUi/CommonUi/TopBarButton.cs) |
+
+### Demo
+
+| File | What it shows |
+|---|---|
+| [`../../TimberUi/TimberUiDemo/UI/DevModeButton.cs`](../../TimberUi/TimberUiDemo/UI/DevModeButton.cs) | `GrouplessBottomBarButton` subclass: `SpritePath`, `Click`, `BottomText`. |
+| [`../../TimberUi/TimberUiDemo/ModConfigs.cs`](../../TimberUi/TimberUiDemo/ModConfigs.cs) | `MultiBind<BottomBarModule>().ToProvider<BottomBarModuleProvider<DevModeButton>>()` in a `[Context("Game")]` configurator. |

--- a/Docs/TimberUi/BuildingUi.MD
+++ b/Docs/TimberUi/BuildingUi.MD
@@ -190,7 +190,7 @@ parent.AddGameButtonPadded("Reset", onClick: Reset, paddingX: 8, paddingY: 4);
 | `Game` | In-game panels and fragments |
 | `EntityFragment` | Inside entity-panel fragments |
 
-`GameButtonSize` values are `Medium` (default), `Small`, and `Large`. Not all style/size combinations produce a visible size difference — `Game` style has no size modifier.
+`GameButtonSize` has three values: `Medium`, `Small`, and `Large`. **On `AddButton` / `AddMenuButton` / `AddGameButton`, only `Medium` and `Large` are supported — passing `Small` throws `NotImplementedException`.** (`Small` is meant for the square icon buttons: `AddSquareButton` / `AddPlusButton` / `AddMinusButton`.) When you omit `size` entirely, no size-modifier class is applied. Not all style/size combinations produce a visible difference — `Game` style has no size modifier.
 
 ### Entity-fragment buttons
 
@@ -205,6 +205,10 @@ NineSliceButton btn = parent.AddEntityFragmentButton(
 
 // Add an inventory icon inside the button's content area
 btn.Q("Content").AddInventoryOutputImage();
+
+// Stretched variant — fills the available column width
+NineSliceButton wide = parent.AddStretchedEntityFragmentButton(
+    text: "Fill All", onClick: FillAll, color: EntityFragmentButtonColor.Green);
 ```
 
 ### Close, plus, and minus buttons
@@ -380,8 +384,11 @@ Image img3 = parent.AddImage(myTexture2D);
 // Load from mod asset path via IAssetLoader
 Image img4 = parent.AddImage("Assets/MyMod/Textures/icon.png", assetLoader);
 
-// By named-icon key via NamedIconProvider
-Image img5 = parent.AddImage("ScienceIcon", namedIconProvider);
+// Via NamedIconProvider. The (iconName, provider) overload resolves the name
+// through the provider's indexer, which throws KeyNotFoundException if that name
+// has not been loaded yet. Prefer one of the provider's named properties (which
+// lazy-load), passing the sprite to the AddImage(Sprite) overload:
+Image img5 = parent.AddImage(namedIconProvider.Science);
 ```
 
 ### `AddIconSpan`
@@ -561,6 +568,50 @@ Toggle t = parent.AddToggle(
 
 ---
 
+## Composite widgets
+
+Two higher-level widgets save you from assembling common patterns by hand.
+
+### `ToggleGroup<TValue>` — mutually-exclusive toggles (radio buttons)
+
+`ToggleGroup<TValue>` turns a set of `Toggle`s into a radio group: exactly one is selected at a time, and selecting one deselects the rest. It is a *controller*, not a `VisualElement` — you create the toggles (which are added to your tree as usual) and hand them to the group, which wires the exclusivity and exposes the selected value.
+
+```cs
+using TimberUi.CommonUi;
+
+// One toggle per value (each AddToggle adds a child to `parent`);
+// the group manages exclusivity over them.
+var group = new ToggleGroup<Difficulty>(
+    [Difficulty.Easy, Difficulty.Normal, Difficulty.Hard],
+    value => parent.AddToggle(value.ToString(), style: ToggleStyle.Settings));
+
+group.OnValueChanged += (_, value) => ApplyDifficulty(value);
+
+// Read or set the selection
+Difficulty current = group.Value;
+group.SetValue(Difficulty.Normal);              // fires OnValueChanged
+group.SetValueWithoutNotify(Difficulty.Hard);   // silent
+```
+
+The first option is selected automatically when the group is built. Other members: `Options` (the `ToggleGroupOption<TValue>` list), `SelectedOption`, `FindOption(value)`, and `ClearSelection()`. A second constructor takes a ready-made `IEnumerable<ToggleGroupOption<TValue>>` if you already hold the toggles.
+
+> Give each value a distinct, non-`default` `TValue` — the group compares against `default(TValue)` internally to track the "nothing selected" state.
+
+### `RecipeRow` — a ready-made recipe display
+
+`RecipeRow` renders a full crafting recipe — ingredients (plus optional fuel), an arrow, the cycle time, and products (plus optional science) — as a single row of `IconSpan`s. It **is** a `VisualElement`, built for you from a Timberborn `RecipeSpec` by the injectable **`RecipeRowFactory`** (`[BindSingleton]`).
+
+```cs
+// Inject RecipeRowFactory recipeRowFactory.
+// recipeSpec is Timberborn's RecipeSpec describing the recipe.
+RecipeRow row = recipeRowFactory.Create(recipeSpec);
+parent.Add(row);
+```
+
+After construction you can reach the individual icons: `row.Ingredients` and `row.Products` (each an `ImmutableArray<IconSpan>`), `row.Time`, and the nullable `row.Fuel` / `row.Science`. Note the fuel icon is exposed only through `Fuel` (it is **not** part of `Ingredients`), and science only through `Science` (not part of `Products`).
+
+---
+
 ## Scroll views and list views
 
 ```cs
@@ -650,6 +701,7 @@ element.Initialize(visualElementLoader);
 | `AddGameButton(text?, onClick?, ...)` | `NineSliceButton` | `GameButtonStyle.Game` |
 | `AddGameButtonPadded(text?, onClick?, ..., paddingX?, paddingY?)` | `NineSliceButton` | Game + explicit padding |
 | `AddEntityFragmentButton(text?, onClick?, name?, additionalClasses?, color?)` | `NineSliceButton` | Green or Red border |
+| `AddStretchedEntityFragmentButton(text?, onClick?, name?, additionalClasses?, color?, stretched?)` | `NineSliceButton` | Stretched entity-fragment button |
 | `AddCloseButton(name?)` | `Button` | Standard close `×` button |
 | `AddPlusButton(name?, size?)` | `NineSliceButton` | |
 | `AddMinusButton(name?, size?)` | `NineSliceButton` | |
@@ -750,6 +802,9 @@ element.Initialize(visualElementLoader);
 | `ImageSource` | `Sprite` / `Texture` / `VectorImage` union | [`CommonUi/IconSpan.cs`](../../TimberUi/TimberUi/CommonUi/) |
 | `ProgressBarWithLabel` | `(TProgressBar, Label)` record | [`CommonUi/`](../../TimberUi/TimberUi/CommonUi/) |
 | `CollapsiblePanel` | Collapsible header + body | [`CommonUi/`](../../TimberUi/TimberUi/CommonUi/) |
+| `ToggleGroup<TValue>` | Radio-style mutually-exclusive toggle controller | [`CommonUi/ToggleGroup.cs`](../../TimberUi/TimberUi/CommonUi/ToggleGroup.cs) |
+| `ToggleGroupOption<TValue>` | `(Toggle Toggle, TValue Value)` group member | [`CommonUi/ToggleGroup.cs`](../../TimberUi/TimberUi/CommonUi/ToggleGroup.cs) |
+| `RecipeRow` / `RecipeRowFactory` | Ready-made recipe display row; factory is `[BindSingleton]` | [`CommonUi/RecipeRow.cs`](../../TimberUi/TimberUi/CommonUi/RecipeRow.cs) |
 | `EntityPanelFragmentElement` | Styled fragment root container | [`CommonUi/`](../../TimberUi/TimberUi/CommonUi/) |
 | `EntityPanelFragmentBackground` | Background color enum | [`CommonUi/`](../../TimberUi/TimberUi/CommonUi/) |
 | `UiCssClasses` | USS class name constants | [`UiCssClasses.cs`](../../TimberUi/TimberUi/UiCssClasses.cs) |

--- a/Docs/TimberUi/BuildingUi.MD
+++ b/Docs/TimberUi/BuildingUi.MD
@@ -6,7 +6,9 @@ The builder extension methods live in `UnityEngine.UIElements`, but several type
 
 - **`using UiBuilder;`** — style enums: `GameLabelStyle`, `GameLabelSize`, `GameLabelColor`, `GameButtonStyle`, `GameButtonSize`, `ToggleStyle`
 - **`using TimberUi;`** — `UiCssClasses`
-- **`using TimberUi.CommonUi;`** — widget types returned by builders: `GameSlider`, `GameSliderInt`, `DropdownRow<>`, `IconSpan`, `ImageSource`, `CollapsiblePanel`, `ProgressBarWithLabel`, `MinMaxSliderValues`
+- **`using TimberUi.CommonUi;`** — widget types returned by builders: `GameSlider`, `GameSliderInt`, `DropdownRow<>`, `IconSpan`, `ImageSource`, `CollapsiblePanel`, `ProgressBarWithLabel`
+
+(`MinMaxSliderValues` lives in `UnityEngine.UIElements`, so it needs no extra `using`.)
 
 A typical fragment therefore needs all three in addition to the standard `UnityEngine.UIElements` import.
 
@@ -321,21 +323,22 @@ cbo.SetSelectedItem(0);
 // 1. Minimal — populate later
 DropdownRow<Difficulty> row = parent.AddDropdownRow<Difficulty>(
     label:    "Difficulty",
-    onChange: e => ApplyDifficulty(e.Value));
+    onChange: e => ApplyDifficulty(e.Item.Value));
 
 // 2. Pre-populated from DropdownRowItem<TValue> collection
 var items = new[]
 {
-    new DropdownRowItem<Difficulty>("Easy",   Difficulty.Easy),
-    new DropdownRowItem<Difficulty>("Normal", Difficulty.Normal),
-    new DropdownRowItem<Difficulty>("Hard",   Difficulty.Hard),
+    // record is (TValue Value, string Text)
+    new DropdownRowItem<Difficulty>(Difficulty.Easy,   "Easy"),
+    new DropdownRowItem<Difficulty>(Difficulty.Normal, "Normal"),
+    new DropdownRowItem<Difficulty>(Difficulty.Hard,   "Hard"),
 };
 DropdownRow<Difficulty> row2 = parent.AddDropdownRow(
     values:     items,
     veInit:     initializer,
     itemSetter: dropdownSetter,
     label:      "Difficulty",
-    onChange:   e => ApplyDifficulty(e.Value));
+    onChange:   e => ApplyDifficulty(e.Item.Value));
 
 // 3. Pre-populated from raw values + display-string function
 DropdownRow<int> row3 = parent.AddDropdownRow(
@@ -416,10 +419,10 @@ parent.AddInventoryOutputImage();
 
 ### `AddProgressBar`
 
-A bare `TProgressBar` with the `progress-bar` class:
+A bare progress bar with the `progress-bar` class. The return type is Timberborn's `ProgressBar` (`Timberborn.CoreUI.ProgressBar`, which TimberUi aliases internally as `TProgressBar`); from your own code, declare it as `ProgressBar` or just use `var`:
 
 ```cs
-TProgressBar bar = parent.AddProgressBar()
+var bar = parent.AddProgressBar()        // Timberborn.CoreUI.ProgressBar
     .SetFlexGrow()
     .SetColor(ProgressBarColor.Green);
 
@@ -430,7 +433,7 @@ bar.SetProgress(ratio, label: null, text: null,
 
 ### `AddProgressBarWithLabel`
 
-Returns a `ProgressBarWithLabel` record struct `(TProgressBar ProgressBar, Label Label)` that keeps bar and label in sync:
+Returns a `ProgressBarWithLabel` record struct `(ProgressBar ProgressBar, Label Label)` that keeps bar and label in sync:
 
 ```cs
 ProgressBarWithLabel pgb = parent.AddProgressBarWithLabel(
@@ -505,7 +508,7 @@ element.SetHeightPercent(100f);
 element.SetMaxWidth(400f);
 element.SetMaxHeight(200f);
 element.SetMinSize(100f, 30f);   // min-width, min-height
-element.SetMinMaxSize(120f, 30f); // clamps min = max = exact size
+element.SetMinMaxSize(120f, 30f); // (width, height) — pins each to min = max = value
 ```
 
 ### Flex layout
@@ -698,7 +701,7 @@ element.Initialize(visualElementLoader);
 
 | Method | Returns | Notes |
 |---|---|---|
-| `AddProgressBar(name?, additionalClasses?)` | `TProgressBar` | |
+| `AddProgressBar(name?, additionalClasses?)` | `ProgressBar` | `Timberborn.CoreUI.ProgressBar` (aliased `TProgressBar` internally) |
 | `AddProgressBarWithLabel(color?, text?, name?, additionalClasses?)` | `ProgressBarWithLabel` | |
 | `SetColor(color, removeColor?)` | same bar | Add or remove a color class |
 | `SetProgress(progress, label?, text?, oldColor?, newColor?)` | same bar | |
@@ -741,8 +744,8 @@ element.Initialize(visualElementLoader);
 | `SliderValues<TValue>` | `(Low, High, Default)` range record | [`CommonUi/GameSlider.cs`](../../TimberUi/TimberUi/CommonUi/GameSlider.cs) |
 | `MinMaxSliderValues` | `(Value, Min, Max)` for range sliders | [`Extensions/Sliders.cs`](../../TimberUi/TimberUi/Extensions/Sliders.cs) |
 | `DropdownRow<TValue>` | Typed label + dropdown | [`CommonUi/DropdownRow.cs`](../../TimberUi/TimberUi/CommonUi/) |
-| `DropdownRowItem<TValue>` | `(Text, Value)` item record | [`CommonUi/DropdownRow.cs`](../../TimberUi/TimberUi/CommonUi/) |
-| `IndexedDropdownRowItem<TValue>` | `(Text, Value, Index)` in change events | [`CommonUi/DropdownRow.cs`](../../TimberUi/TimberUi/CommonUi/) |
+| `DropdownRowItem<TValue>` | `(TValue Value, string Text)` item record | [`CommonUi/DropdownRow.cs`](../../TimberUi/TimberUi/CommonUi/) |
+| `IndexedDropdownRowItem<TValue>` | `(int Index, DropdownRowItem<TValue> Item)` in change events | [`CommonUi/DropdownRow.cs`](../../TimberUi/TimberUi/CommonUi/) |
 | `IconSpan` | Image + optional label row | [`CommonUi/IconSpan.cs`](../../TimberUi/TimberUi/CommonUi/) |
 | `ImageSource` | `Sprite` / `Texture` / `VectorImage` union | [`CommonUi/IconSpan.cs`](../../TimberUi/TimberUi/CommonUi/) |
 | `ProgressBarWithLabel` | `(TProgressBar, Label)` record | [`CommonUi/`](../../TimberUi/TimberUi/CommonUi/) |

--- a/Docs/TimberUi/BuildingUi.MD
+++ b/Docs/TimberUi/BuildingUi.MD
@@ -1,0 +1,752 @@
+# Building UI with the UiBuilder DSL
+
+TimberUi's UiBuilder DSL is a set of extension methods on Unity's `VisualElement` that let you assemble a complete UI tree in a straight, readable chain. Every `Add…` call creates a child element, parents it, applies the right game CSS classes, and returns the new element so the next call can chain off it. Every `Set…` call mutates the element and returns the same element. The result matches Timberborn's visual style — menus, entity-panel fragments, and settings panels all use these methods internally.
+
+The builder extension methods live in `UnityEngine.UIElements`, but several types require additional `using` directives:
+
+- **`using UiBuilder;`** — style enums: `GameLabelStyle`, `GameLabelSize`, `GameLabelColor`, `GameButtonStyle`, `GameButtonSize`, `ToggleStyle`
+- **`using TimberUi;`** — `UiCssClasses`
+- **`using TimberUi.CommonUi;`** — widget types returned by builders: `GameSlider`, `GameSliderInt`, `DropdownRow<>`, `IconSpan`, `ImageSource`, `CollapsiblePanel`, `ProgressBarWithLabel`, `MinMaxSliderValues`
+
+A typical fragment therefore needs all three in addition to the standard `UnityEngine.UIElements` import.
+
+> **Source:** [`../../TimberUi/TimberUi/Extensions/`](../../TimberUi/TimberUi/Extensions/)
+
+---
+
+## The core pattern: building a tree
+
+### `AddChild`, `AddRow`, `AddHorizontalContainer`
+
+Every builder ultimately goes through `AddChild`, which creates an element, adds it to the parent, and optionally sets its name and CSS classes:
+
+```cs
+// Generic: creates a typed child with new()
+Button btn = parent.AddChild<Button>(name: "my-button", classes: ["my-class"]);
+
+// Factory overload: for types that need constructor arguments
+var row = parent.AddChild<DropdownRow<int>>(() => new DropdownRow<int>());
+
+// Untyped: creates a plain VisualElement
+VisualElement spacer = parent.AddChild(name: "spacer");
+```
+
+For horizontal layouts, `AddRow` and `AddHorizontalContainer` are the everyday shortcuts:
+
+```cs
+// AddRow — sets flexDirection: row; returns the row
+var row = panel.AddRow();
+
+// AddHorizontalContainer — row + 20px bottom margin (pass false to suppress)
+var con = panel.AddHorizontalContainer();
+var con2 = panel.AddHorizontalContainer(marginBottom: false);
+```
+
+A full fragment `InitializeFragment` typically looks like this:
+
+```cs
+public VisualElement InitializeFragment()
+{
+    panel = new EntityPanelFragmentElement
+    {
+        Background = EntityPanelFragmentBackground.Green
+    };
+
+    var row = panel.AddHorizontalContainer();
+    row.AddGameLabel("Coordinates".Bold());
+    lblCoord = row.AddGameLabel("N/A");
+
+    panel.Initialize(initializer);   // required — see Initializing game widgets
+    return panel;
+}
+```
+
+### Inserting elements relative to an existing sibling
+
+When you need to inject an element next to one that already exists in the tree:
+
+```cs
+newElement.InsertSelfBefore(existingElement);
+newElement.InsertSelfAfter(existingElement);
+// or at an arbitrary offset:
+newElement.InsertSelfAsSibling(existingElement, delta: 2);
+```
+
+---
+
+## Labels and text
+
+### `AddLabel`, `AddLabelHeader`, `AddGameLabel`
+
+```cs
+// Plain game label — "text--default" USS class
+Label lbl = parent.AddLabel("Hello");
+
+// Header variant — "text--header"
+Label hdr = parent.AddLabelHeader("Section title");
+
+// Full game-label with size, color, bold, and centering control
+Label big = parent.AddGameLabel(
+    text:     "42",
+    size:     GameLabelSize.Big,
+    color:    GameLabelColor.Yellow,
+    bold:     true,
+    centered: false);
+```
+
+`AddLabel` accepts an optional `style` parameter from `GameLabelStyle`:
+
+| `GameLabelStyle` | USS classes applied |
+|---|---|
+| `Default` (default) | `text--default` |
+| `Header` | `text--header` |
+| `Game` | `game-text-normal` (+ size/color/bold modifiers) |
+| `EntityFragment` | `entity-panel__text` |
+
+`AddGameLabel` accepts `GameLabelSize` and `GameLabelColor`:
+
+| `GameLabelSize` | `GameLabelColor` |
+|---|---|
+| `Normal` (default) | `Default` (no color modifier) |
+| `Big` | `Yellow` |
+
+After creation, you can add the same label classes to any `TextElement` you constructed manually:
+
+```cs
+existingLabel.AddLabelClasses(GameLabelStyle.Game, size: GameLabelSize.Big, bold: true);
+```
+
+### Rich-text decorators
+
+`Texts.cs` adds extension methods on `string` that return Unity TextMeshPro markup. Compose them inline:
+
+```cs
+parent.AddLabel(
+    $"Status: {"online".Color(TimberbornTextColor.Green)} — " +
+    $"{"WARNING".Bold().Color(TimberbornTextColor.Red)}");
+
+parent.AddLabel("Note: " + "alt-click to type a value".Italic());
+parent.AddLabel("Cost: " + "50".Bold().Color("#FFD700"));
+```
+
+| Method | Markup produced |
+|---|---|
+| `"x".Bold()` | `<b>x</b>` |
+| `"x".Italic()` | `<i>x</i>` |
+| `"x".Size(18)` | `<size=18>x</size>` |
+| `"x".Strikethrough()` | `<s>x</s>` |
+| `"x".Highlight()` | yellow color markup |
+| `"x".Color(TimberbornTextColor.Green/Red/Yellow)` | `<color=#…>x</color>` |
+| `"x".Color("#FF0000")` or `"x".Color("FF0000")` | custom hex color |
+
+`TimberbornTextColor` has three members: `Green`, `Red`, and `Yellow` (`Solid` is a deprecated alias for `Yellow`).
+
+---
+
+## Buttons
+
+### `AddButton` — the universal button
+
+```cs
+// Action overload (most common)
+NineSliceButton btn = parent.AddButton(
+    text:    "Confirm",
+    onClick: OnConfirm,
+    style:   GameButtonStyle.Menu,
+    size:    GameButtonSize.Large,
+    stretched: false);
+
+// EventCallback overload (gives access to the click event)
+NineSliceButton btn2 = parent.AddButton(
+    text:    "Cancel",
+    clickCb: evt => { evt.StopPropagation(); Cancel(); },
+    style:   GameButtonStyle.Game);
+```
+
+### Style shortcuts
+
+```cs
+// Menu button (default style — most settings and dialog buttons)
+parent.AddMenuButton("Apply", onClick: Apply);
+
+// In-game button (used in entity panels and HUD)
+parent.AddGameButton("Reset", onClick: Reset);
+
+// In-game button with explicit padding (pixels X, Y)
+parent.AddGameButtonPadded("Reset", onClick: Reset, paddingX: 8, paddingY: 4);
+```
+
+### `GameButtonStyle` reference
+
+| Value | Usage |
+|---|---|
+| `Text` | Unstyled, bold text only |
+| `Menu` (default) | Main-menu and settings panels |
+| `WideMenu` | Wide variant of menu button |
+| `BottomBar` | Bottom action bar |
+| `DevPanel` | Developer panel |
+| `Game` | In-game panels and fragments |
+| `EntityFragment` | Inside entity-panel fragments |
+
+`GameButtonSize` values are `Medium` (default), `Small`, and `Large`. Not all style/size combinations produce a visible size difference — `Game` style has no size modifier.
+
+### Entity-fragment buttons
+
+Fragment panels use a specialized button with a colored border:
+
+```cs
+// Green or Red border variant
+NineSliceButton btn = parent.AddEntityFragmentButton(
+    text:  "Fill",
+    onClick: FillAll,
+    color: EntityFragmentButtonColor.Green);
+
+// Add an inventory icon inside the button's content area
+btn.Q("Content").AddInventoryOutputImage();
+```
+
+### Close, plus, and minus buttons
+
+```cs
+Button closeBtn = parent.AddCloseButton();
+
+// Plus / minus — size controls the icon scale
+NineSliceButton plusBtn  = parent.AddPlusButton(size: GameButtonSize.Small);
+NineSliceButton minusBtn = parent.AddMinusButton(size: GameButtonSize.Medium);
+```
+
+### Adding a click handler to an existing button
+
+`AddAction` registers a callback on any `Button` and returns the same button, so it chains:
+
+```cs
+plusBtn.AddAction(Add);
+minusBtn.AddAction(Subtract).SetMarginRight();
+```
+
+---
+
+## Input fields
+
+### Text, integer, and float fields
+
+Each creates a styled `NineSlice*Field` with the `text-field` USS class:
+
+```cs
+NineSliceTextField   txt  = parent.AddTextField(changeCallback: OnNameChanged);
+NineSliceIntegerField num = parent.AddIntField(changeCallback: OnCountChanged);
+NineSliceFloatField  flt  = parent.AddFloatField(changeCallback: OnRatioChanged);
+```
+
+Callbacks receive the new value directly — no need to unwrap a `ChangeEvent`. All three support optional `name` and `additionalClasses` parameters.
+
+---
+
+## Sliders
+
+### `AddSlider` and `AddSliderInt`
+
+These return a `GameSlider` or `GameSliderInt` — a pre-styled row (`settings-slider` / `settings-text` classes) wrapping the underlying `Slider` or `SliderInt`.
+
+```cs
+GameSlider    floatSlider = parent.AddSlider(
+    label:  "Speed",
+    values: new SliderValues<float>(Low: 0f, High: 10f, Default: 1f));
+
+GameSliderInt intSlider = parent.AddSliderInt(
+    label:  "Workers",
+    values: new SliderValues<int>(Low: 0, High: 20, Default: 5));
+```
+
+After adding, chain slider configuration:
+
+```cs
+intSlider
+    .RegisterChange(v => workerCount = v)
+    .AddEndLabel(v => $"{v} workers")   // live-updating label on the right
+    .SetValue(currentWorkerCount);
+```
+
+`SetValueWithoutNotify` silently updates both the slider position and the end label without firing change callbacks.
+
+### Alt-click to type an exact value
+
+`GameSlider` and `GameSliderInt` support an optional mode where alt-clicking the slider opens an `InputDialogBox` so the user can type a precise number. Inject `GameSliderAlternativeManualValueDI` and call:
+
+```cs
+intSlider.RegisterAlternativeManualValue(altValueDI, prompt: "Enter worker count");
+```
+
+### `AddMinMaxSlider`
+
+For a range selector (two thumbs):
+
+```cs
+MinMaxSlider range = parent.AddMinMaxSlider(
+    values:         new MinMaxSliderValues(Value: new Vector2(2f, 8f), Min: 0f, Max: 10f),
+    changeCallback: v => ApplyRange(v.x, v.y),
+    label:          "Range");
+
+// Fluent control after creation
+range.SetValue(new MinMaxSliderValues(new Vector2(3f, 7f), 0f, 10f));
+range.SetValueWithoutNotify(new Vector2(3f, 7f));
+```
+
+---
+
+## Dropdowns
+
+### `AddDropdown` — raw Timberborn `Dropdown`
+
+A bare `Dropdown` requires a `DropdownItemsSetter` (injected) to populate it:
+
+```cs
+Dropdown cbo = parent.AddDropdown()
+    .AddChangeHandler((value, index) => OnSelectionChanged(index));
+
+// Populate (after the element is initialized — see below)
+cbo.SetItems(dropdownSetter, ["Option A", "Option B", "Option C"]);
+cbo.SetSelectedItem(0);
+```
+
+`AddMenuDropdown` is identical but adds the `settings-dropdown` USS class for a menu-styled appearance.
+
+`GetSelectedValue()` returns the selected string; `GetSelectedIndex()` returns the zero-based index, or `-1` when nothing is selected or the dropdown is not yet populated. `SetSelectedItem(int)` throws `ArgumentOutOfRangeException` if the index is out of range.
+
+### `AddDropdownRow<TValue>` — typed label + dropdown
+
+`DropdownRow<TValue>` pairs a label with a typed dropdown and fires a strongly-typed `OnValueChanged` event. Three overloads are available:
+
+```cs
+// 1. Minimal — populate later
+DropdownRow<Difficulty> row = parent.AddDropdownRow<Difficulty>(
+    label:    "Difficulty",
+    onChange: e => ApplyDifficulty(e.Value));
+
+// 2. Pre-populated from DropdownRowItem<TValue> collection
+var items = new[]
+{
+    new DropdownRowItem<Difficulty>("Easy",   Difficulty.Easy),
+    new DropdownRowItem<Difficulty>("Normal", Difficulty.Normal),
+    new DropdownRowItem<Difficulty>("Hard",   Difficulty.Hard),
+};
+DropdownRow<Difficulty> row2 = parent.AddDropdownRow(
+    values:     items,
+    veInit:     initializer,
+    itemSetter: dropdownSetter,
+    label:      "Difficulty",
+    onChange:   e => ApplyDifficulty(e.Value));
+
+// 3. Pre-populated from raw values + display-string function
+DropdownRow<int> row3 = parent.AddDropdownRow(
+    values:     Enumerable.Range(1, 10),
+    textFn:     v => $"Level {v}",
+    veInit:     initializer,
+    itemSetter: dropdownSetter,
+    label:      "Level");
+```
+
+To select an item programmatically:
+
+```cs
+row.SetSelectedValue(Difficulty.Hard);
+row.SetSelectedIndex(2);
+
+// Without firing OnValueChanged
+row.SetSelectedValueWithoutNotifying(Difficulty.Normal);
+row.SetSelectedIndexWithoutNotifying(1);
+```
+
+---
+
+## Images and icons
+
+### `AddImage` overloads
+
+```cs
+// By USS class name — the class provides the background sprite
+// Use the named argument; a bare string binds to the `name` overload, not the class overload
+Image img1 = parent.AddImage(className: "my-icon-class");
+
+// By Sprite reference
+Image img2 = parent.AddImage(mySprite);
+
+// By Texture
+Image img3 = parent.AddImage(myTexture2D);
+
+// Load from mod asset path via IAssetLoader
+Image img4 = parent.AddImage("Assets/MyMod/Textures/icon.png", assetLoader);
+
+// By named-icon key via NamedIconProvider
+Image img5 = parent.AddImage("ScienceIcon", namedIconProvider);
+```
+
+### `AddIconSpan`
+
+`IconSpan` is a pre-styled row of optional prefix text + image + optional postfix text:
+
+```cs
+// From any ImageSource (Sprite / Texture / VectorImage — implicit conversions exist)
+IconSpan span = parent.AddIconSpan(mySprite, prefixText: "50", postfixText: " kg");
+
+// Arrow glyph from NamedIconProvider (used in recipe rows)
+IconSpan arrow = parent.AddArrow(namedIconProvider);
+```
+
+Content helpers on an existing `IconSpan`:
+
+```cs
+span.SetGood(goodService, "Timberborn.Planks", amount: "10");
+span.SetScience(namedIconProvider, amount: "25");
+span.SetTime(namedIconProvider, time: "2.5s");
+```
+
+### Inventory slot images
+
+Two shorthand adders give you the standard input/output tray icons used in building panels:
+
+```cs
+parent.AddInventoryInputImage();
+parent.AddInventoryOutputImage();
+```
+
+---
+
+## Progress bars
+
+### `AddProgressBar`
+
+A bare `TProgressBar` with the `progress-bar` class:
+
+```cs
+TProgressBar bar = parent.AddProgressBar()
+    .SetFlexGrow()
+    .SetColor(ProgressBarColor.Green);
+
+// Update value (0–1) and swap color in one call
+bar.SetProgress(ratio, label: null, text: null,
+    oldColor: ProgressBarColor.Green, newColor: ProgressBarColor.Red);
+```
+
+### `AddProgressBarWithLabel`
+
+Returns a `ProgressBarWithLabel` record struct `(TProgressBar ProgressBar, Label Label)` that keeps bar and label in sync:
+
+```cs
+ProgressBarWithLabel pgb = parent.AddProgressBarWithLabel(
+    color: ProgressBarColor.Teal,
+    text:  "0%");
+
+// Simplest update — convenience method sets bar + label together
+pgb.SetProgress(ratio, $"{ratio * 100:F0}%");
+
+// Or update the bar directly when you need color-swap or other control
+pgb.ProgressBar.SetProgress(ratio, pgb.Label, $"{ratio * 100:F0}%");
+```
+
+### `ProgressBarColor`
+
+| Value | Color |
+|---|---|
+| `Green` (default) | Green |
+| `Teal` | Teal |
+| `Red` | Red |
+| `Blue` | Blue |
+
+`SetColor(color, removeColor: true)` removes a color class (use when swapping colors so the old class is cleaned up).
+
+---
+
+## Styling with `Properties.cs`
+
+Every `Set…` and `Add…Class` method returns the same element, so they chain directly onto any builder call.
+
+### CSS classes
+
+```cs
+element.AddClass("my-class");
+element.AddClasses("class-a", "class-b", "class-c");
+```
+
+### Margins and padding
+
+```cs
+// Single value — applies to all sides
+element.SetMargin(10f);
+
+// X/Y shorthand — (marginX: left+right, marginY: top+bottom)
+element.SetMargin(marginX: 8f, marginY: 4f);
+
+// Per-side (top, right, bottom, left)
+element.SetMargin(top: 0, right: 20, bottom: 20, left: 0);
+
+// Convenience helpers — default value is 20px
+element.SetMarginRight();          // 20px right margin
+element.SetMarginBottom(12f);      // 12px bottom margin
+element.SetMarginLeftAuto();       // auto left margin (push right)
+
+// Padding follows the same pattern
+element.SetPadding(5f);
+element.SetPadding(paddingX: 8f, paddingY: 4f);
+element.SetPadding(top: 2, right: 10, bottom: 2, left: 10);
+```
+
+### Size
+
+```cs
+element.SetWidth(200f);
+element.SetHeight(40f);
+element.SetSize(200f, 40f);      // width, height
+element.SetSize(40f);            // square
+
+element.SetWidthPercent(50f);    // 50% of parent
+element.SetHeightPercent(100f);
+
+element.SetMaxWidth(400f);
+element.SetMaxHeight(200f);
+element.SetMinSize(100f, 30f);   // min-width, min-height
+element.SetMinMaxSize(120f, 30f); // clamps min = max = exact size
+```
+
+### Flex layout
+
+```cs
+// Switch any element to row direction
+element.SetAsRow();
+
+// Flex grow / shrink
+element.SetFlexGrow();           // grow = 1 (fills available space)
+element.SetFlexGrow(2f);
+element.SetFlexShrink();         // shrink = 1
+element.SetWrap();               // enable flex-wrap
+
+// Align children
+element.AlignItems(Align.Center);    // default
+element.AlignItems(Align.FlexStart);
+element.JustifyContent(Justify.SpaceBetween);
+```
+
+### Visibility and borders
+
+```cs
+element.SetDisplay(visible);              // true = flex, false = none
+element.SetBorder(color: Color.red, width: 2f);
+```
+
+### Naming an element at construction time
+
+```cs
+element.SetName("my-element");
+```
+
+---
+
+## Collapsible panels and toggles
+
+```cs
+// Collapsible panel — header with +/- buttons and a collapsible body
+CollapsiblePanel cp = parent.AddCollapsiblePanel(title: "Advanced options", expand: false);
+cp.Container.AddLabel("Hidden content");
+cp.ExpandChanged += expanded => Debug.Log($"Expanded: {expanded}");
+
+// Toggle (settings style)
+Toggle t = parent.AddToggle(
+    text:           "Enable feature",
+    style:          ToggleStyle.Settings,
+    onValueChanged: v => featureEnabled = v);
+```
+
+---
+
+## Scroll views and list views
+
+```cs
+// Scroll view with green decoration (default)
+ScrollView sv = parent.AddScrollView();
+
+// Game-styled scroll view
+ScrollView gsv = parent.AddGameScrollView();
+
+// List view (same USS class as scroll view; green-decorated by default)
+ListView lv = parent.AddListView(greenDecorated: false);
+```
+
+---
+
+## Initializing game widgets
+
+Several Timberborn controls — sliders, dropdowns, text fields — need their `VisualElementInitializer` to run before they respond to input or display correctly. Call `Initialize` **after** building the element tree and **before** returning from `InitializeFragment`:
+
+```cs
+public VisualElement InitializeFragment()
+{
+    panel = new EntityPanelFragmentElement
+    {
+        Background = EntityPanelFragmentBackground.Green
+    };
+
+    slider   = panel.AddSliderInt(label: "Count", values: new(0, 10, 5));
+    dropdown = panel.AddDropdown();
+
+    // Initialize the whole tree in one call — resolves on all children recursively
+    panel.Initialize(initializer);
+
+    // Populate the dropdown after initializing
+    dropdown.SetItems(dropdownSetter, ["A", "B", "C"]);
+
+    return panel;
+}
+```
+
+`Initialize` has two overloads:
+
+```cs
+// From a VisualElementInitializer (injected directly)
+element.Initialize(visualElementInitializer);
+
+// From a VisualElementLoader (injected in some contexts — extracts its initializer)
+element.Initialize(visualElementLoader);
+```
+
+`AddDropdownRow` with `veInit` and `itemSetter` arguments calls `Initialize` for you automatically. For all other widget types, and for entity-panel fragments built on `EntityPanelFragmentElement`, call it explicitly on the root before returning.
+
+---
+
+## Builder reference
+
+### Layout primitives
+
+| Method | Returns | Notes |
+|---|---|---|
+| `AddChild<T>(name?, classes?)` | `T` | Generic, requires `new()` |
+| `AddChild<T>(Func<T> factory)` | `T` | For types with constructor args |
+| `AddChild(Type?, name?, classes?)` | `VisualElement` | Untyped |
+| `AddRow(name?)` | `VisualElement` | `flexDirection: row` |
+| `AddHorizontalContainer(marginBottom?)` | `VisualElement` | Row + 20px bottom margin |
+| `AddScrollView(name?, additionalClasses?, greenDecorated?)` | `ScrollView` | |
+| `AddGameScrollView(name?, additionalClasses?)` | `ScrollView` | |
+| `AddListView(name?, additionalClasses?, greenDecorated?)` | `ListView` | |
+| `AddCollapsiblePanel(title?, expand?, name?)` | `CollapsiblePanel` | |
+| `AddFragment(background?, name?, additionalClasses?)` | `EntityPanelFragmentElement` | |
+
+### Labels
+
+| Method | Returns | Notes |
+|---|---|---|
+| `AddLabel(text?, name?, additionalClasses?, style?)` | `Label` | `GameLabelStyle.Default` |
+| `AddLabelHeader(text?, name?, additionalClasses?)` | `Label` | `GameLabelStyle.Header` |
+| `AddGameLabel(text?, name?, additionalClasses?, size?, color?, bold?, centered?)` | `Label` | Full control |
+
+### Buttons
+
+| Method | Returns | Notes |
+|---|---|---|
+| `AddButton(text?, name?, onClick?, additionalClasses?, style?, size?, stretched?)` | `NineSliceButton` | Action overload |
+| `AddButton(text?, clickCb?, name?, additionalClasses?, style?, size?, stretched?)` | `NineSliceButton` | EventCallback overload |
+| `AddMenuButton(text?, onClick?, ...)` | `NineSliceButton` | `GameButtonStyle.Menu` |
+| `AddGameButton(text?, onClick?, ...)` | `NineSliceButton` | `GameButtonStyle.Game` |
+| `AddGameButtonPadded(text?, onClick?, ..., paddingX?, paddingY?)` | `NineSliceButton` | Game + explicit padding |
+| `AddEntityFragmentButton(text?, onClick?, name?, additionalClasses?, color?)` | `NineSliceButton` | Green or Red border |
+| `AddCloseButton(name?)` | `Button` | Standard close `×` button |
+| `AddPlusButton(name?, size?)` | `NineSliceButton` | |
+| `AddMinusButton(name?, size?)` | `NineSliceButton` | |
+| `AddAction(onClick)` | `T` (same button) | Chains onto any `Button` |
+
+### Input fields
+
+| Method | Returns | Notes |
+|---|---|---|
+| `AddTextField(name?, changeCallback?, additionalClasses?)` | `NineSliceTextField` | |
+| `AddIntField(name?, changeCallback?, additionalClasses?)` | `NineSliceIntegerField` | |
+| `AddFloatField(name?, changeCallback?, additionalClasses?)` | `NineSliceFloatField` | |
+
+### Sliders
+
+| Method | Returns | Notes |
+|---|---|---|
+| `AddSlider(label?, name?, additionalClasses?, values?)` | `GameSlider` | Float |
+| `AddSliderInt(label?, name?, additionalClasses?, values?)` | `GameSliderInt` | Int |
+| `AddMinMaxSlider(values?, changeCallback?, label?, name?, additionalClasses?)` | `MinMaxSlider` | |
+
+### Dropdowns
+
+| Method | Returns | Notes |
+|---|---|---|
+| `AddDropdown(name?, additionalClasses?)` | `Dropdown` | |
+| `AddMenuDropdown(name?, additionalClasses?)` | `Dropdown` | `settings-dropdown` class |
+| `AddDropdownRow<TValue>(label?, onChange?, veInit?, itemSetter?)` | `DropdownRow<TValue>` | |
+| `AddDropdownRow<TValue>(values, veInit, itemSetter, label?, onChange?, generateUniqueNames?)` | `DropdownRow<TValue>` | Pre-populated |
+| `AddDropdownRow<TValue>(values, textFn, veInit, itemSetter, label?, onChange?, generateUniqueNames?)` | `DropdownRow<TValue>` | Pre-populated |
+
+### Images
+
+| Method | Returns | Notes |
+|---|---|---|
+| `AddImage(name?, additionalClasses?)` | `Image` | Bare image |
+| `AddImage(className, name?, additionalClasses?)` | `Image` | USS class as source |
+| `AddImage(Sprite, name?, additionalClasses?)` | `Image` | |
+| `AddImage(Texture, name?, additionalClasses?)` | `Image` | |
+| `AddImage(path, IAssetLoader, name?, additionalClasses?)` | `Image` | Loads from mod assets |
+| `AddImage(iconName, NamedIconProvider, name?, additionalClasses?)` | `Image` | Named icon |
+| `AddIconSpan()` | `IconSpan` | Empty span |
+| `AddIconSpan(ImageSource, prefix?, postfix?, size?)` | `IconSpan` | With content |
+| `AddArrow(NamedIconProvider)` | `IconSpan` | Arrow glyph |
+| `AddInventoryInputImage()` | `Image` | Inventory input tray |
+| `AddInventoryOutputImage()` | `Image` | Inventory output tray |
+
+### Progress bars
+
+| Method | Returns | Notes |
+|---|---|---|
+| `AddProgressBar(name?, additionalClasses?)` | `TProgressBar` | |
+| `AddProgressBarWithLabel(color?, text?, name?, additionalClasses?)` | `ProgressBarWithLabel` | |
+| `SetColor(color, removeColor?)` | same bar | Add or remove a color class |
+| `SetProgress(progress, label?, text?, oldColor?, newColor?)` | same bar | |
+
+### Styling (`Properties.cs`)
+
+| Method | Notes |
+|---|---|
+| `AddClass(className)` | |
+| `AddClasses(params …)` | |
+| `SetMargin(…)` / `SetMarginBottom()` / `SetMarginRight()` / `SetMarginLeftAuto()` | |
+| `SetPadding(…)` | |
+| `SetWidth(f)` / `SetHeight(f)` / `SetSize(w, h)` | Pixel values |
+| `SetWidthPercent(f)` / `SetHeightPercent(f)` / `SetSizePercent(w, h)` | |
+| `SetMaxWidth/Height/Size(…)` / `SetMinSize(…)` / `SetMinMaxSize(…)` | |
+| `SetAsRow()` | `flexDirection: row` |
+| `SetFlexGrow(n?)` / `SetFlexShrink(n?)` / `SetWrap(bool?)` | |
+| `SetDisplay(bool)` | `flex` or `none` |
+| `AlignItems(Align)` / `JustifyContent(Justify)` | |
+| `SetBorder(color?, width?)` | |
+| `SetName(string)` | |
+| `Initialize(VisualElementInitializer)` / `Initialize(VisualElementLoader)` | Required for sliders, dropdowns, and fragment roots |
+
+---
+
+## Key types
+
+| Type | Role | Source |
+|---|---|---|
+| `GameLabelStyle` | Label visual variant enum | [`UiEnums.cs`](../../TimberUi/TimberUi/UiEnums.cs) |
+| `GameLabelSize` | Normal / Big | [`UiEnums.cs`](../../TimberUi/TimberUi/UiEnums.cs) |
+| `GameLabelColor` | Default / Yellow | [`UiEnums.cs`](../../TimberUi/TimberUi/UiEnums.cs) |
+| `GameButtonStyle` | Button variant enum | [`UiEnums.cs`](../../TimberUi/TimberUi/UiEnums.cs) |
+| `GameButtonSize` | Medium / Small / Large | [`UiEnums.cs`](../../TimberUi/TimberUi/UiEnums.cs) |
+| `TimberbornTextColor` | Green / Red / Yellow | [`Texts.cs`](../../TimberUi/TimberUi/Extensions/Texts.cs) |
+| `ProgressBarColor` | Green / Teal / Red / Blue | [`ProgressBars.cs`](../../TimberUi/TimberUi/Extensions/ProgressBars.cs) |
+| `EntityFragmentButtonColor` | Green / Red | [`Buttons.cs`](../../TimberUi/TimberUi/Extensions/Buttons.cs) |
+| `ToggleStyle` | Settings | [`UiEnums.cs`](../../TimberUi/TimberUi/UiEnums.cs) |
+| `GameSlider` / `GameSliderInt` | Styled slider widget | [`CommonUi/GameSlider.cs`](../../TimberUi/TimberUi/CommonUi/GameSlider.cs) |
+| `SliderValues<TValue>` | `(Low, High, Default)` range record | [`CommonUi/GameSlider.cs`](../../TimberUi/TimberUi/CommonUi/GameSlider.cs) |
+| `MinMaxSliderValues` | `(Value, Min, Max)` for range sliders | [`Extensions/Sliders.cs`](../../TimberUi/TimberUi/Extensions/Sliders.cs) |
+| `DropdownRow<TValue>` | Typed label + dropdown | [`CommonUi/DropdownRow.cs`](../../TimberUi/TimberUi/CommonUi/) |
+| `DropdownRowItem<TValue>` | `(Text, Value)` item record | [`CommonUi/DropdownRow.cs`](../../TimberUi/TimberUi/CommonUi/) |
+| `IndexedDropdownRowItem<TValue>` | `(Text, Value, Index)` in change events | [`CommonUi/DropdownRow.cs`](../../TimberUi/TimberUi/CommonUi/) |
+| `IconSpan` | Image + optional label row | [`CommonUi/IconSpan.cs`](../../TimberUi/TimberUi/CommonUi/) |
+| `ImageSource` | `Sprite` / `Texture` / `VectorImage` union | [`CommonUi/IconSpan.cs`](../../TimberUi/TimberUi/CommonUi/) |
+| `ProgressBarWithLabel` | `(TProgressBar, Label)` record | [`CommonUi/`](../../TimberUi/TimberUi/CommonUi/) |
+| `CollapsiblePanel` | Collapsible header + body | [`CommonUi/`](../../TimberUi/TimberUi/CommonUi/) |
+| `EntityPanelFragmentElement` | Styled fragment root container | [`CommonUi/`](../../TimberUi/TimberUi/CommonUi/) |
+| `EntityPanelFragmentBackground` | Background color enum | [`CommonUi/`](../../TimberUi/TimberUi/CommonUi/) |
+| `UiCssClasses` | USS class name constants | [`UiCssClasses.cs`](../../TimberUi/TimberUi/UiCssClasses.cs) |

--- a/Docs/TimberUi/DependencyInjection.MD
+++ b/Docs/TimberUi/DependencyInjection.MD
@@ -1,0 +1,343 @@
+# Dependency Injection
+
+TimberUi's DI layer turns what would be a wall of `Bind<T>().AsSingleton()` calls into a handful of attributes on your classes. You declare **one `AttributeConfigurator` subclass per game context**, decorate each class you want to register with a `[Bind…]` attribute (or the more specialised `[BindFragment]` / `[AddTemplateModule2]`), and TimberUi scans your assembly at configure time and wires everything for you. For the cases where attributes are not enough — overriding a game service, bulk-replacing bindings, or manually wiring a template-module decorator — a set of imperative fluent helpers on `Configurator` covers the gaps.
+
+**Relevant source:** [`../../TimberUi/TimberUi/`](../../TimberUi/TimberUi/)
+
+---
+
+## Setting up the configurators
+
+### Subclass one base per context
+
+Timberborn's DI runs four separate `Configure()` passes, one per _game context_ (Bootstrapper, MainMenu, Game, MapEditor). TimberUi provides a matching abstract base for each:
+
+| Base class | Context | Typical use |
+|---|---|---|
+| `BootstrapperAttributeConfigurator` | Bootstrapper | Services needed from game start before any scene |
+| `MainMenuAttributeConfigurator` | Main menu | Services and UI only needed on the main-menu screen |
+| `GameAttributeConfigurator` | In-game session | Services, fragments, template-module decorators |
+| `MapEditorAttributeConfigurator` | Map editor | Same as Game but for the editor scene |
+
+Subclass whichever contexts your mod needs and tag each with Timberborn's `[Context]` attribute. The `Configure()` method is already implemented on the base — it calls `this.BindAttributes(Context, GetAssembly())` — so an empty body is all you need:
+
+```cs
+[Context("Game")]
+public class MyModGameConfig : GameAttributeConfigurator { }
+
+[Context("MainMenu")]
+public class MyModMenuConfig : MainMenuAttributeConfigurator { }
+```
+
+That is the entire setup. Any class in the same assembly that carries a matching `[Bind…]` attribute is picked up automatically.
+
+### Scanning a different assembly
+
+`GetAssembly()` defaults to `GetType().Assembly` — the assembly that contains your configurator subclass. If your `[Bind…]`-decorated types live in a separate assembly (a shared library, for example), override the property:
+
+```cs
+[Context("Game")]
+public class MyModGameConfig : GameAttributeConfigurator
+{
+    public override Assembly GetAssembly() => typeof(MySharedLibraryAnchor).Assembly;
+}
+```
+
+---
+
+## The `BindAttributeContext` filter
+
+Every `[Bind…]` attribute carries a `Contexts` flag that controls in which DI scope the type is registered. The enum members and their combinations are:
+
+| Value | Numeric | Meaning |
+|---|---|---|
+| `MainMenu` | 1 | Main-menu scene only |
+| `Game` | 2 | In-game session only |
+| `MapEditor` | 4 | Map-editor scene only |
+| `Bootstrapper` | 8 | Bootstrapper scope only |
+| `All` | 7 | `MainMenu \| Game \| MapEditor` |
+| `NonMenu` | 6 | `Game \| MapEditor` |
+
+> `All` does **not** include `Bootstrapper`. A type decorated with `[Bind(Contexts = BindAttributeContext.All)]` is not registered in the bootstrapper scope.
+
+The default value on all `[Bind…]` attributes is `Game` unless the attribute overrides it (e.g. `[BindMenuSingleton]` defaults to `MainMenu`).
+
+---
+
+## The attribute family
+
+### `[Bind]` — the base attribute
+
+[`[Bind]`](../../TimberUi/TimberUi/DIAttributes/BindAttribute.cs) is the general-purpose registration attribute. All the convenience attributes below are subclasses that preset one or more of its properties.
+
+| Property | Type | Default | Meaning |
+|---|---|---|---|
+| `Contexts` | `BindAttributeContext` | `Game` | Which context(s) this registration applies to |
+| `Scope` | `Scope?` | `null` (use configurator default) | `Singleton` or `Transient`; null inherits the configurator's default (singleton) |
+| `As` | `Type?` | `null` (bind to self) | The service interface or base type to expose |
+| `AlsoBindSelf` | `bool` | `false` | When `As` is set, also register the concrete type directly |
+| `Exported` | `bool` | `false` | Mark the binding as exported (visible to parent containers) |
+| `MultiBind` | `bool` | `false` | Register into a multibind collection of type `As` instead of a single binding |
+
+`[Bind]` has `AllowMultiple = true`, so you can stack multiple attributes on the same class to register it in different ways — for example, as a game-context singleton _and_ a menu-context binding:
+
+```cs
+[Bind(Contexts = BindAttributeContext.Game,     Scope = Scope.Singleton, As = typeof(IMyService))]
+[Bind(Contexts = BindAttributeContext.MainMenu, Scope = Scope.Transient)]
+public class MyService : IMyService { /* ... */ }
+```
+
+### Convenience shorthand attributes
+
+[`BindHelpers.cs`](../../TimberUi/TimberUi/DIAttributes/BindHelpers.cs) provides the shorthand attributes you will use day-to-day:
+
+**`[BindSingleton]`** — binds the class to itself as a singleton in the `Game` context (or whatever `Contexts` you set):
+
+```cs
+[BindSingleton]
+public class MyGameService { /* ... */ }
+```
+
+To expose an interface, set `As`:
+
+```cs
+[BindSingleton(As = typeof(IMyService))]
+public class MyService : IMyService { /* ... */ }
+```
+
+**`[BindTransient]`** — same as `[BindSingleton]` but with `Scope.Transient`:
+
+```cs
+[BindTransient]
+public class MyTransientHelper { /* ... */ }
+```
+
+**`[BindMenuSingleton]`** — shorthand for `[BindSingleton(Contexts = MainMenu)]`:
+
+```cs
+[BindMenuSingleton]
+public class MyMenuService { /* ... */ }
+```
+
+**`[MultiBind(typeof(IService))]`** — registers the class into the multibind collection for `IService`. The `As` type is required (passed as a constructor argument):
+
+```cs
+[MultiBind(typeof(IMyListener))]
+public class MyListener : IMyListener { /* ... */ }
+```
+
+To also make the concrete type directly resolvable alongside the multibind entry, set `AlsoBindSelf = true` on a plain `[Bind]`:
+
+```cs
+[Bind(As = typeof(IMyListener), MultiBind = true, AlsoBindSelf = true, Scope = Scope.Singleton)]
+public class MyListener : IMyListener { /* ... */ }
+```
+
+### `[BindFragment]` — entity-panel fragments
+
+[`[BindFragment]`](../../TimberUi/TimberUi/DIAttributes/BindHelpers.cs) marks a class as an entity-panel fragment. The class **must** implement `IEntityPanelFragment` (TimberUi validates this at configure time and throws if it does not). Fragment registration only runs in a `NonMenu` context (`Game` or `MapEditor`), so make sure the configurator that scans your assembly is one of `GameAttributeConfigurator` or `MapEditorAttributeConfigurator`.
+
+If the class also implements `IEntityFragmentOrder`, TimberUi automatically calls `BindOrderedFragment` so the position ordering is wired too:
+
+```cs
+[BindFragment]
+public class MyBuildingFragment : BaseEntityPanelFragment<MyComponent> { /* ... */ }
+```
+
+`[BindFragment]` does not carry a `Contexts` property — the active context drives it entirely.
+
+### `[AddTemplateModule2]` — template-module decorators
+
+[`[AddTemplateModule2]`](../../TimberUi/TimberUi/DIAttributes/AddTemplateModuleAttribute.cs) registers a class as a decorator on a Timberborn `TemplateModule` subject type. It is the current attribute for this purpose; the older `[AddTemplateModule]` is marked `[Obsolete]` and should be avoided in new code.
+
+| Property | Type | Default | Meaning |
+|---|---|---|---|
+| `Subject` (ctor arg) | `Type` | required | The template type to decorate |
+| `Contexts` | `BindAttributeContext` | `Game` | Which contexts this decorator applies to |
+| `AlsoBindTransient` | `bool` | `true` | Automatically bind the decorator class as transient |
+
+Template-module registration only runs in a `NonMenu` context. The `Contexts` property then further filters within that: a decorator with `Contexts = Game` is skipped when the active context is `MapEditor`, and vice versa.
+
+```cs
+[AddTemplateModule2(typeof(Workplace))]
+public class MyWorkplaceDecorator { /* ... */ }
+```
+
+To apply the same decorator in both the game and map-editor scenes:
+
+```cs
+[AddTemplateModule2(typeof(Workplace), Contexts = BindAttributeContext.NonMenu)]
+public class MyWorkplaceDecorator { /* ... */ }
+```
+
+---
+
+## Adding extra bindings imperatively
+
+When an attribute is not enough — conditional wiring, dynamic types, or overriding bindings the game registered — use the fluent `Configurator` extension methods. These live in [`Extensions/Configurators.cs`](../../TimberUi/TimberUi/Extensions/Configurators.cs) and [`Extensions/ConfiguratorHelpers.cs`](../../TimberUi/TimberUi/Extensions/ConfiguratorHelpers.cs) (namespace `Bindito.Core`), so they appear directly on `Configurator` inside any `Configure()` override.
+
+All of these return `Configurator`, so they chain:
+
+```cs
+public override void Configure()
+{
+    base.Configure(); // run attribute scan first
+
+    this.BindSingleton<MyExtraService>()
+        .BindFragment<MyExtraFragment>();
+}
+```
+
+### `BindSingleton` and `BindTransient`
+
+Bind a single type or an interface→implementation pair at a fixed scope:
+
+```cs
+// Bind MyService to itself as a singleton
+this.BindSingleton<MyService>();
+
+// Bind IMyService → MyService as a singleton
+this.BindSingleton<IMyService, MyService>();
+
+// Bind MyHelper to itself as transient
+this.BindTransient<MyHelper>();
+```
+
+### Multibinding
+
+Add an implementation to a multibind collection and also register it as a singleton so it is directly resolvable:
+
+```cs
+// MultiBind<T> + Bind<TImpl>.AsSingleton() in one call
+this.MultiBindAndBindSingleton<IMyListener, MyListener>();
+
+// MultiBind only (no separate singleton binding)
+this.MultiBindSingleton<IMyListener, MyListener>();
+```
+
+### Template-module decorators
+
+Use `BindTemplateModule` with a lambda to add decorators in one fluent call. The lambda receives a `TemplateModuleHelper`, call `AddDecorator` on it, and return it — the helper's `Bind()` is called for you:
+
+```cs
+this.BindTemplateModule(h => h
+    .AddDecorator<Workplace, MyWorkplaceDecorator>()
+    .AddDecorator<Dwelling, MyDwellingDecorator>()
+);
+```
+
+`AddDecorator<TSubject, TDecorator>` also binds the decorator class as transient by default (`addTransient = true`). Pass `false` to skip that if you are binding the decorator separately.
+
+For multi-step setup, use the two-call form and call `Bind()` explicitly:
+
+```cs
+var helper = this.BindTemplateModule();
+helper.AddDecorator<Workplace, MyWorkplaceDecorator>();
+helper.Bind();
+```
+
+### Removing and rebinding game services
+
+`RemoveBinding<T>()` removes an existing single binding from the container so you can replace it with your own:
+
+```cs
+this.RemoveBinding<ISomeGameService>();
+this.BindSingleton<ISomeGameService, MyReplacementService>();
+```
+
+For replacing several services at once, `MassRebind` is more efficient — it batches the removes and re-adds in a single pass:
+
+```cs
+this.MassRebind(h => h
+    .Replace<IFoo, MyFoo>()          // removes IFoo, binds IFoo → MyFoo as singleton
+    .Replace<IBar, MyBar>()
+    .Remove<IObsoleteService>()       // removes without replacement
+);
+```
+
+`Replace<TRemove, TReplace>` also binds `TReplace` to itself by default (`alsoBindReplacement = true`). Pass `false` to suppress that.
+
+> **Single bindings only.** `RemoveBinding` and `MassRebind` operate on single bindings only; they do not touch multibindings. To remove or replace a multibound game service use `RemoveMultibinding`/`RemoveMultibindings` or `MassRemoveMultibindings` instead.
+
+### `IsBound` and `TryBind`
+
+When writing a helper that may be called from multiple mods, guard registrations with `IsBound`/`TryBind` to avoid double-binding errors:
+
+```cs
+// Only register if nothing has claimed ISharedService yet
+if (!this.IsBound<ISharedService>())
+{
+    this.BindSingleton<ISharedService, DefaultSharedService>();
+}
+
+// Equivalent one-liner: returns ISingleBindingBuilder<T> (null if already bound)
+this.TryBind<ISharedService>()?.To<DefaultSharedService>().AsSingleton();
+```
+
+---
+
+## Complete example
+
+```cs
+// -- MyMod/Configs/GameConfig.cs --
+
+[Context("Game")]
+public class MyModGameConfig : GameAttributeConfigurator
+{
+    public override void Configure()
+    {
+        base.Configure(); // attribute scan runs here
+
+        // Extra wiring that attributes cannot express:
+        this.BindTemplateModule(h => h
+            .AddDecorator<Building, MyBuildingStats>()
+        );
+    }
+}
+
+// -- MyMod/Services/MyGameService.cs --
+
+[BindSingleton]
+public class MyGameService { /* ... */ }
+
+// -- MyMod/Services/MyEventListener.cs --
+
+[MultiBind(typeof(IGameEventListener))]
+public class MyEventListener : IGameEventListener { /* ... */ }
+
+// -- MyMod/Fragments/MyBuildingFragment.cs --
+
+[BindFragment]
+public class MyBuildingFragment : BaseEntityPanelFragment<Building> { /* ... */ }
+
+// -- MyMod/Decorators/MyBuildingStats.cs --
+// Registered imperatively above via BindTemplateModule because it needs
+// a non-Game context variant in a sibling mod that uses MapEditor context.
+
+public class MyBuildingStats { /* ... */ }
+```
+
+---
+
+## Key types
+
+| Type | Role |
+|---|---|
+| [`AttributeConfigurator`](../../TimberUi/TimberUi/AttributeConfigurator.cs) | Abstract base; `Configure()` calls `BindAttributes(Context, GetAssembly())`. Subclass via one of the four concrete bases. |
+| [`GameAttributeConfigurator`](../../TimberUi/TimberUi/AttributeConfigurator.cs) | Ready-to-subclass base for the `Game` context |
+| [`MainMenuAttributeConfigurator`](../../TimberUi/TimberUi/AttributeConfigurator.cs) | Ready-to-subclass base for the `MainMenu` context |
+| [`MapEditorAttributeConfigurator`](../../TimberUi/TimberUi/AttributeConfigurator.cs) | Ready-to-subclass base for the `MapEditor` context |
+| [`BootstrapperAttributeConfigurator`](../../TimberUi/TimberUi/AttributeConfigurator.cs) | Ready-to-subclass base for the `Bootstrapper` context |
+| [`BindAttribute`](../../TimberUi/TimberUi/DIAttributes/BindAttribute.cs) | Base registration attribute; supports `Contexts`, `Scope`, `As`, `AlsoBindSelf`, `Exported`, `MultiBind` |
+| [`BindAttributeContext`](../../TimberUi/TimberUi/DIAttributes/BindAttribute.cs) | `[Flags]` enum: `MainMenu`, `Game`, `MapEditor`, `Bootstrapper`, `All` (excludes Bootstrapper), `NonMenu` |
+| [`BindSingletonAttribute`](../../TimberUi/TimberUi/DIAttributes/BindHelpers.cs) | `[Bind]` preset to `Scope.Singleton`, default context `Game` |
+| [`BindTransientAttribute`](../../TimberUi/TimberUi/DIAttributes/BindHelpers.cs) | `[Bind]` preset to `Scope.Transient`, default context `Game` |
+| [`BindMenuSingletonAttribute`](../../TimberUi/TimberUi/DIAttributes/BindHelpers.cs) | `[BindSingleton]` preset to `Contexts = MainMenu` |
+| [`MultiBindAttribute`](../../TimberUi/TimberUi/DIAttributes/BindHelpers.cs) | `[Bind]` preset to `MultiBind = true`; requires the `As` type as a constructor argument |
+| [`BindFragmentAttribute`](../../TimberUi/TimberUi/DIAttributes/BindHelpers.cs) | Marker attribute for `IEntityPanelFragment` types; only active in `NonMenu` contexts |
+| [`AddTemplateModule2Attribute`](../../TimberUi/TimberUi/DIAttributes/AddTemplateModuleAttribute.cs) | Current template-module decorator attribute; supports `Subject`, `Contexts`, `AlsoBindTransient` |
+| [`AttributeBinder`](../../TimberUi/TimberUi/DIAttributes/AttributeBinder.cs) | Static engine; called by `AttributeConfigurator.Configure()` to scan the assembly and apply all attributes |
+| `UiBuilderExtensions` (in `Bindito.Core`) | Hosts `BindAttributes`, `BindSingleton`, `BindTransient`, `MultiBindSingleton`, `MultiBindAndBindSingleton`, `BindFragment`, `BindOrderedFragment`, `RemoveBinding`, `MassRemoveBindings`, `IsBound`, `TryBind`, `TryMultiBind` as extension methods on `Configurator` — source: [`Extensions/Configurators.cs`](../../TimberUi/TimberUi/Extensions/Configurators.cs) |
+| [`TemplateModuleHelper`](../../TimberUi/TimberUi/Helpers/ConfiguratorHelpers.cs) | Fluent builder for `TemplateModule` decorator wiring; obtained via `configurator.BindTemplateModule()` |
+| [`MassRebindingHelper`](../../TimberUi/TimberUi/Helpers/ConfiguratorHelpers.cs) | Batches `Replace` and `Remove` operations on existing bindings; obtained via `configurator.MassRebind()` |
+| [`MConfigs`](../../TimberUi/TimberUi/MConfigs.cs) | TimberUi's own four configurators (`MBootstrapperConfig`, `MMenuConfig`, `MGameConfig`, `MMapConfig`) that register library-internal services — referenced here for orientation, not subclassed by consumer mods |

--- a/Docs/TimberUi/DependencyInjection.MD
+++ b/Docs/TimberUi/DependencyInjection.MD
@@ -51,6 +51,7 @@ Every `[Bind…]` attribute carries a `Contexts` flag that controls in which DI 
 
 | Value | Numeric | Meaning |
 |---|---|---|
+| `None` | 0 | No contexts (the empty/default value) |
 | `MainMenu` | 1 | Main-menu scene only |
 | `Game` | 2 | In-game session only |
 | `MapEditor` | 4 | Map-editor scene only |

--- a/Docs/TimberUi/DevTools.MD
+++ b/Docs/TimberUi/DevTools.MD
@@ -1,0 +1,206 @@
+# Developer Panel Tools
+
+Timberborn ships a collapsible **dev panel** that, when visible, lists sections of clickable debug actions. Each section is contributed by a registered `IDevModule` implementation. TimberUi lets your mod add its own section to this panel with a straightforward multibind plus two game types — and because the dev panel exposes the live UI tree through a `PanelStack`, it is also a convenient hook for dumping UXML snapshots using TimberUi's `PrintVisualTree` extension.
+
+This page shows how to:
+
+1. Implement `IDevModule` and register it.
+2. Dump the live visual tree from a dev action.
+3. Add a bottom-bar toggle button for dev mode.
+
+For the `PrintVisualTree` / `DescribeVisualTree` extension details and all `UxmlExporter.ExportOptions` flags, see [Utilities.MD — Visual-tree debugging](./Utilities.MD#visual-tree-debugging).  
+For bottom-bar registration mechanics, see [AlertsAndBars.MD — Bottom-bar modules](./AlertsAndBars.MD#1-bottom-bar-modules).
+
+---
+
+## 1. What the dev panel is
+
+The dev panel is a Timberborn game-side overlay (shown or hidden by `DevModeManager`) that contains one collapsible card per registered `IDevModule`. Each card has a header (derived from the module's definition) and one button per registered method. Clicking a button calls the `Action` you supplied.
+
+`IDevModule`, `DevModuleDefinition`, `DevMethod`, and `DevModeManager` are **Timberborn game types** from the `Timberborn.Debugging` namespace (`PanelStack` is also a Timberborn game type, from `Timberborn.CoreUI`). TimberUi does not wrap or re-export them — it only makes registration easier via its `MultiBind` helper.
+
+---
+
+## 2. Writing an `IDevModule`
+
+Implement `IDevModule.GetDefinition()` and return a `DevModuleDefinition` built with its fluent builder. Each entry in the panel is a `DevMethod` that pairs a label string with an `Action`.
+
+The demo's `PrintVisualTreeDevModule` is a minimal, complete example:
+
+```cs
+// TimberUiDemo/UI/PrintVisualTreeDevModule.cs
+namespace TimberUiDemo.UI;
+
+public class PrintVisualTreeDevModule(PanelStack panelStack) : IDevModule
+{
+    public DevModuleDefinition GetDefinition()
+    {
+        return new DevModuleDefinition.Builder()
+            .AddMethod(DevMethod.Create("Print PanelStack root Visual Tree", PrintVisualTree))
+            .Build();
+    }
+
+    void PrintVisualTree()
+    {
+        panelStack._root.PrintVisualTree(true);
+    }
+}
+```
+
+Key points:
+
+- The class receives its dependencies through constructor injection. `PanelStack` is a Timberborn game singleton; inject whatever services your debug action needs.
+- `DevModuleDefinition.Builder.AddMethod` accepts a `DevMethod` returned by `DevMethod.Create(label, action)`. Call `AddMethod` once per button you want in the card.
+- `.Build()` finalises the definition and returns it.
+- Your action method can be `void` or `async void`. If it performs async work (e.g. opening a dialog, see `BvmDevModule` in the same repo) it should be `async void` and awaited internally.
+
+### Adding multiple buttons
+
+Call `AddMethod` repeatedly — each call adds one more button to the card:
+
+```cs
+public DevModuleDefinition GetDefinition()
+{
+    return new DevModuleDefinition.Builder()
+        .AddMethod(DevMethod.Create("Dump UI tree",   DumpUiTree))
+        .AddMethod(DevMethod.Create("Reset counters", ResetCounters))
+        .Build();
+}
+```
+
+---
+
+## 3. Registering the module
+
+In your `[Context("Game")]` configurator, multibind your implementation into `IDevModule`:
+
+```cs
+// ModConfigs.cs
+[Context("Game")]
+public class GameConfigs : Configurator
+{
+    public override void Configure()
+    {
+        MultiBind<IDevModule>().To<PrintVisualTreeDevModule>().AsSingleton();
+    }
+}
+```
+
+`MultiBind<IDevModule>()` is the standard Bindito multibind call — no TimberUi extension needed. Using `.AsSingleton()` ensures the same instance handles every button click.
+
+The game collects all `IDevModule` registrations and builds a panel card for each one at startup. You may register as many modules as you like; each gets its own card.
+
+---
+
+## 4. Dumping the visual tree
+
+Getting a UXML snapshot of the live UI hierarchy is the main use-case in the demo. The entry point is the `PrintVisualTree` extension that TimberUi adds to every `VisualElement`:
+
+```cs
+void PrintVisualTree()
+{
+    // Logs the full UXML of the PanelStack root (templates expanded) to the Unity console.
+    panelStack._root.PrintVisualTree(true);
+}
+```
+
+`panelStack._root` is the root `VisualElement` of Timberborn's main UI hierarchy. Injecting `PanelStack` (a Timberborn game type) and accessing its `_root` field is exactly how the demo reaches it.
+
+If you want to capture the output as a string rather than log it immediately, use `DescribeVisualTree` instead:
+
+```cs
+void CaptureTree()
+{
+    string uxml = panelStack._root.DescribeVisualTree();
+    // write to file, show in a dialog, etc.
+}
+```
+
+Both methods live in TimberUi's `Extensions/Helpers.cs` (namespace `UnityEngine.UIElements`). For the full signature including the `templateId` and `options` parameters, and for the `UxmlExporter.ExportOptions` flag table, see [Utilities.MD — Visual-tree debugging](./Utilities.MD#visual-tree-debugging).
+
+> **Note on the bool overload.** `PrintVisualTree(bool)` ignores its argument — it always expands templates (`UxmlExporter.ExportOptions.PrintTemplate`), which is why the demo simply calls `PrintVisualTree(true)`. The no-argument `PrintVisualTree()` binds a *different* overload that uses default options (templates not expanded); use the `(templateId?, options?)` overload and pass explicit `options` when you need control over the export flags.
+
+---
+
+## 5. Dev-mode toggle button
+
+If your mod has UI that should only appear while dev mode is active, you can surface a bottom-bar toggle button that calls `DevModeManager.Enable()` / `DevModeManager.Disable()`. The demo does this via a `GrouplessBottomBarButton` subclass:
+
+```cs
+// TimberUiDemo/UI/DevModeButton.cs
+namespace TimberUiDemo.UI;
+
+public class DevModeButton : GrouplessBottomBarButton
+{
+    readonly DevModeManager devMode;
+
+    public DevModeButton(VisualElementLoader veLoader, IAssetLoader assetLoader, DevModeManager devMode)
+        : base(veLoader, assetLoader)
+    {
+        SpritePath = "Sprites/timberui-dev";
+        Click      = ToggleDevMode;
+        BottomText = "Dev Mode";
+
+        this.devMode = devMode;
+    }
+
+    void ToggleDevMode()
+    {
+        if (devMode.Enabled)
+            devMode.Disable();
+        else
+            devMode.Enable();
+    }
+}
+```
+
+`GrouplessBottomBarButton` and `DevModeManager` are **Timberborn game types**. `GrouplessBottomBarButton` requires `VisualElementLoader` and `IAssetLoader` through its base constructor. Set `SpritePath`, `Click`, and `BottomText` in your constructor before the bar is first rendered.
+
+Register it in the same `[Context("Game")]` configurator, alongside the `IDevModule` binding:
+
+```cs
+[Context("Game")]
+public class GameConfigs : Configurator
+{
+    public override void Configure()
+    {
+        Bind<DevModeButton>().AsSingleton();
+        MultiBind<BottomBarModule>().ToProvider<BottomBarModuleProvider<DevModeButton>>().AsSingleton();
+
+        MultiBind<IDevModule>().To<PrintVisualTreeDevModule>().AsSingleton();
+    }
+}
+```
+
+`BottomBarModuleProvider<T>` is a **TimberUi** type that adds your element to the right section of the bottom bar. See [AlertsAndBars.MD — Bottom-bar modules](./AlertsAndBars.MD#1-bottom-bar-modules) for the full registration walkthrough.
+
+---
+
+## Key types
+
+| Type | Kind | Namespace | Role |
+|---|---|---|---|
+| `IDevModule` | Timberborn game type | `Timberborn.Debugging` | Interface to implement; `GetDefinition()` returns the panel card definition. |
+| `DevModuleDefinition` | Timberborn game type | `Timberborn.Debugging` | Describes a dev panel card; built via `DevModuleDefinition.Builder`. |
+| `DevMethod` | Timberborn game type | `Timberborn.Debugging` | A labeled button entry; created with `DevMethod.Create(label, action)`. |
+| `DevModeManager` | Timberborn game type | `Timberborn.Debugging` | Singleton that exposes `Enabled`, `Enable()`, and `Disable()` for dev mode state. |
+| `PanelStack` | Timberborn game type | `Timberborn.CoreUI` (resolved via DI) | Holds `_root`, the root `VisualElement` of the game's main UI hierarchy. |
+| `GrouplessBottomBarButton` | Timberborn game type | `Timberborn.BottomBarSystem` | Base class for a simple bottom-bar button; set `SpritePath`, `Click`, `BottomText`. |
+| `BottomBarModuleProvider<T>` | TimberUi type | `TimberUi.CommonProviders` | `IProvider<BottomBarModule>`; adds `T` to the right section of the bottom bar. |
+| `PrintVisualTree()` | TimberUi extension | `UnityEngine.UIElements` | Logs the UXML of a `VisualElement` to the Unity console. |
+| `DescribeVisualTree()` | TimberUi extension | `UnityEngine.UIElements` | Returns the UXML of a `VisualElement` as a string without logging. |
+
+### Demo source
+
+| File | What it shows |
+|---|---|
+| [`../../TimberUi/TimberUiDemo/UI/PrintVisualTreeDevModule.cs`](../../TimberUi/TimberUiDemo/UI/PrintVisualTreeDevModule.cs) | Full `IDevModule` implementation: `GetDefinition()`, `DevModuleDefinition.Builder`, `DevMethod.Create`, and calling `PrintVisualTree` on a panel root. |
+| [`../../TimberUi/TimberUiDemo/UI/DevModeButton.cs`](../../TimberUi/TimberUiDemo/UI/DevModeButton.cs) | `GrouplessBottomBarButton` subclass wired to `DevModeManager.Enable()` / `Disable()`. |
+| [`../../TimberUi/TimberUiDemo/ModConfigs.cs`](../../TimberUi/TimberUiDemo/ModConfigs.cs) | `[Context("Game")]` configurator with `MultiBind<IDevModule>()`, `Bind<DevModeButton>()`, and `MultiBind<BottomBarModule>()`. |
+
+### Library source
+
+| File | What it provides |
+|---|---|
+| [`../../TimberUi/TimberUi/Extensions/Helpers.cs`](../../TimberUi/TimberUi/Extensions/Helpers.cs) | `PrintVisualTree` and `DescribeVisualTree` extensions on `VisualElement`. |
+| [`../../TimberUi/TimberUi/CommonProviders/BottomBarModuleProvider.cs`](../../TimberUi/TimberUi/CommonProviders/BottomBarModuleProvider.cs) | `BottomBarModuleProvider<T>` implementation. |

--- a/Docs/TimberUi/DevTools.MD
+++ b/Docs/TimberUi/DevTools.MD
@@ -52,7 +52,7 @@ Key points:
 - The class receives its dependencies through constructor injection. `PanelStack` is a Timberborn game singleton; inject whatever services your debug action needs.
 - `DevModuleDefinition.Builder.AddMethod` accepts a `DevMethod` returned by `DevMethod.Create(label, action)`. Call `AddMethod` once per button you want in the card.
 - `.Build()` finalises the definition and returns it.
-- Your action method can be `void` or `async void`. If it performs async work (e.g. opening a dialog, see `BvmDevModule` in the same repo) it should be `async void` and awaited internally.
+- Your action method can be `void` or `async void`. If it performs async work (e.g. opening a dialog — see `BvmDevModule` at `BeavVsMachine/Services/BvmDevModule.cs`, a different mod in this repo), make it `async void` and `await` internally.
 
 ### Adding multiple buttons
 

--- a/Docs/TimberUi/DialogsAndPrompts.MD
+++ b/Docs/TimberUi/DialogsAndPrompts.MD
@@ -1,0 +1,316 @@
+# Dialogs & Prompts
+
+TimberUi provides two layers for showing modal dialogs. In almost every situation you want the **high-level `DialogService`** — inject it, call one method, await the result. When you need a fully custom dialog (custom layout, multiple fields, non-standard sizing) you drop down to **`DialogBoxElement`** and its subclasses and manage the panel yourself.
+
+All dialogs push onto Timberborn's own `PanelStack`, so they participate in the game's modal stack, ESC handling, and the confirm/cancel lifecycle exactly like the game's own dialogs.
+
+---
+
+## `DialogService` — the recommended entry point
+
+`DialogService` is a `[BindSingleton(Contexts = All)]` singleton. Inject it through primary-constructor DI in any service, fragment, or other singleton that needs to show a dialog.
+
+```cs
+[BindSingleton]
+public class MyService(DialogService dialogs)
+{
+    // ...
+}
+```
+
+### Showing an alert
+
+`Alert` is fire-and-forget (no await required). `AlertAsync` returns a `Task` you can await if you need to know when the user dismissed it.
+
+```cs
+// Fire-and-forget — no await
+dialogs.Alert("Operation complete.");
+
+// Localized message key
+dialogs.Alert("MyMod.OperationComplete", localized: true);
+
+// Awaited — continues after the user clicks OK
+await dialogs.AlertAsync("Something happened.");
+```
+
+Both overloads accept a `bool localized` parameter. When `true` the string is treated as a localization key and resolved via `ILoc.T(...)` before display; when `false` (the default) it is shown as-is.
+
+### Asking for confirmation
+
+`ConfirmAsync` shows a dialog with two buttons and returns `true` when the user confirms and `false` when they cancel.
+
+```cs
+bool confirmed = await dialogs.ConfirmAsync("Delete all saved data?");
+
+if (confirmed)
+{
+    DeleteData();
+}
+```
+
+The button labels default to the game's standard OK / Cancel strings. Pass `okText` / `cancelText` to override them with literal strings, or `localizedOkText` / `localizedCancelText` to supply localization keys:
+
+```cs
+// Literal button labels
+bool ok = await dialogs.ConfirmAsync(
+    "Overwrite the file?",
+    okText: "Overwrite",
+    cancelText: "Keep existing"
+);
+
+// Localized button labels
+bool ok = await dialogs.ConfirmAsync(
+    "MyMod.OverwritePrompt",
+    localized: true,
+    localizedOkText: "MyMod.Overwrite",
+    localizedCancelText: "MyMod.KeepExisting"
+);
+```
+
+When `localizedOkText`/`localizedCancelText` is provided it **overrides** the raw `okText`/`cancelText` (the raw value is discarded). If the localized key resolves to an empty string the dialog falls back to its default button text.
+
+### Prompting for text input
+
+`PromptAsync` shows a dialog with a text field and returns the entered string, or `null` if the user cancelled.
+
+```cs
+string? name = await dialogs.PromptAsync(
+    title: "New preset",
+    prompt: "Enter a name:",
+    defaultValue: "My Preset"
+);
+
+if (name is not null)
+{
+    SavePreset(name);
+}
+```
+
+All three parameters are optional. An empty-but-confirmed field returns `""` (not `null`), so check `string.IsNullOrEmpty` if a blank entry is not meaningful to your mod.
+
+```cs
+string? value = await dialogs.PromptAsync(prompt: "Value:");
+if (string.IsNullOrEmpty(value))
+    return;
+```
+
+---
+
+## `DialogBoxElement` — building a custom modal
+
+When you need a dialog that is more than a message and one or two buttons — multiple inputs, a custom layout, explicit sizing — build it directly from `DialogBoxElement`.
+
+`DialogBoxElement` is a plain `VisualElement` subclass. Construct it, configure it, then call `Show` or `ShowAsync` to push it onto the panel stack.
+
+### Minimal custom dialog
+
+```cs
+var dialog = new DialogBoxElement();
+dialog.SetTitle("My Settings");
+dialog.AddCloseButton();
+
+// Add your own content into dialog.Content (a ScrollView)
+dialog.Content.AddGameLabel("Configure things here.");
+
+// Show and await — true = confirmed, false = cancelled/closed
+bool confirmed = await dialog.ShowAsync(veInit, panelStack);
+```
+
+`VisualElementInitializer` and `PanelStack` are both game services — inject them wherever you create dialogs.
+
+### Setting a title
+
+```cs
+dialog.SetTitle("Import Options");
+```
+
+`SetTitle` can be called before or after `Show`. The first call lazily adds the title chrome to the element.
+
+### Adding a close button
+
+```cs
+dialog.AddCloseButton();                         // close = cancel
+dialog.AddCloseButton(() => DoSomethingFirst()); // custom action instead
+```
+
+Without a custom action the close button wires to `OnUICancelled`. A custom action replaces that wiring; calling `AddCloseButton` a second time with a custom action throws, so set it once.
+
+### Controlling dialog size
+
+```cs
+// Fixed pixel size (auto-scaled to screen DPI)
+dialog.SetDialogSize(width: 600, height: 400);
+
+// As a fraction of the screen (0.0–1.0)
+dialog.SetDialogPercentSize(width: 0.4f, height: 0.3f);
+```
+
+Sizing can be called before `Show`; TimberUi defers the pixel calculation until after the dialog is attached to the panel (when DPI scale is available) and then applies it automatically.
+
+### `Show` vs `ShowAsync`
+
+```cs
+// Callback-based — supply confirm/cancel actions directly
+DialogBox box = dialog.Show(veInit, panelStack,
+    confirm: () => Apply(),
+    cancel:  () => Revert()
+);
+
+// Async — await a Task<bool>
+bool ok = await dialog.ShowAsync(veInit, panelStack);
+```
+
+Both push the dialog onto `PanelStack` and return (or resolve) once the user confirms or cancels. The `confirm` / `cancel` callbacks are optional in the synchronous overload; when omitted they default to no-ops.
+
+### Confirming and cancelling programmatically
+
+```cs
+dialog.OnUIConfirmed();   // confirm and close
+dialog.OnUICancelled();   // cancel and close
+dialog.Close();           // close without a confirm/cancel result
+```
+
+---
+
+## `InputDialogBox` — typed value dialogs
+
+`InputDialogBox` and its siblings extend `DialogBoxElement` with a prompt label, a typed input field, and OK/Cancel buttons. `ShowAsync` returns a value tuple `(bool Confirmed, TValueType? Value)`.
+
+Three concrete types are available:
+
+| Class | Input type | Value type |
+|---|---|---|
+| `InputDialogBox` | `NineSliceTextField` | `string` |
+| `IntegerInputDialogBox` | `NineSliceIntegerField` | `int` |
+| `FloatInputDialogBox` | `NineSliceFloatField` | `float` |
+
+### Creating an instance
+
+Use the static factories on `InputDialogBox` to keep construction consistent:
+
+```cs
+var stringDlg  = InputDialogBox.CreateString(t);
+var intDlg     = InputDialogBox.CreateInteger(t);
+var floatDlg   = InputDialogBox.CreateFloat(t);
+```
+
+Or construct the concrete subtype directly (useful when the CRTP fluent chain is important):
+
+```cs
+var dlg = new IntegerInputDialogBox(t);
+```
+
+`ILoc t` is the game's localization service — inject it into the surrounding singleton or fragment.
+
+### Configuring and showing
+
+The fluent setters (`SetPrompt`, `SetValue`, `AddCloseButton`) are chainable and return the concrete type (`InputDialogBox`, `IntegerInputDialogBox`, or `FloatInputDialogBox`), so the chain stays typed. `SetTitle` and `SetDialogSize` come from the base `DialogBoxElement` and return `DialogBoxElement`, which has no typed setters or tuple `ShowAsync` — call them on the variable as separate statements, not mid-chain.
+
+```cs
+var dlg = InputDialogBox.CreateInteger(t);
+dlg.SetTitle("Worker count");
+var (confirmed, value) = await dlg
+    .SetPrompt("How many workers?")
+    .SetValue(4)
+    .AddCloseButton()
+    .ShowAsync(veInit, panelStack);
+if (confirmed)
+{
+    SetWorkers(value!.Value);
+}
+```
+
+`AddCloseButton()` on `InputDialogBox` both adds the close button chrome and makes the Cancel button visible. If you omit it, the Cancel button is hidden and the user can only confirm.
+
+When the dialog is cancelled `Confirmed` is `false` and `Value` is `null` for all value types — the field is `TValueType?`, so even `int` and `float` come back as `null`, not `0`. Always check `Confirmed` (or `value.HasValue`) before using `Value`.
+
+### String input example
+
+```cs
+var dlg = InputDialogBox.CreateString(t);
+dlg.SetTitle("Rename");
+var (ok, name) = await dlg
+    .SetPrompt("New name:")
+    .SetValue(currentName)
+    .AddCloseButton()
+    .ShowAsync(veInit, panelStack);
+if (ok && !string.IsNullOrEmpty(name))
+{
+    Rename(name);
+}
+```
+
+### Float input example
+
+```cs
+var dlg = InputDialogBox.CreateFloat(t);
+dlg.SetTitle("Set threshold");
+var (ok, threshold) = await dlg
+    .SetPrompt("Trigger at:")
+    .SetValue(0.5f)
+    .AddCloseButton()
+    .ShowAsync(veInit, panelStack);
+if (ok)
+{
+    _threshold = threshold!.Value;
+}
+```
+
+---
+
+## `DialogBoxShower.ShowAsync` — the low-level async extension
+
+`TimberUiDialogExtensions.ShowAsync` (in `Extensions/Dialog.cs`) is a thin async wrapper around the game's own `DialogBoxShower` for cases where you want to build a dialog at the `DialogBoxShower.Builder` level rather than through `DialogService`.
+
+```cs
+// Inject DialogBoxShower directly
+bool? result = await diagShower.ShowAsync(
+    "Are you sure?",
+    buttons: ["Yes", "No"]
+);
+```
+
+The return type is `bool?`:
+
+| Return value | Meaning |
+|---|---|
+| `true` | First button (confirm) clicked |
+| `false` | Second button (cancel) clicked |
+| `null` | Third button (info) clicked |
+
+The `buttons` parameter is optional; omitting it shows the default OK button only. Supply up to three entries; any slot beyond the third is ignored. Passing `null` for a slot label uses the game's default text for that button.
+
+```cs
+// Single OK button (alert style)
+await diagShower.ShowAsync("Done.");
+
+// Two buttons
+bool? ok = await diagShower.ShowAsync("Proceed?", ["Go", "Abort"]);
+
+// Three buttons (confirm / cancel / info)
+bool? choice = await diagShower.ShowAsync(
+    "Choose an action",
+    ["Apply", "Discard", "Later"]
+);
+```
+
+By default the message is treated as a localization key (`messageLocalized: true`). Pass `messageLocalized: false` to display the string as-is:
+
+```cs
+await diagShower.ShowAsync(dynamicMessage, messageLocalized: false);
+```
+
+---
+
+## Key types
+
+| Type | Role | Source |
+|---|---|---|
+| [`DialogService`](../../TimberUi/TimberUi/Services/DialogService.cs) | `[BindSingleton(All)]` facade — `Alert`/`AlertAsync`, `ConfirmAsync`, `PromptAsync`. Recommended entry point. | `Services/DialogService.cs` |
+| [`DialogBoxElement`](../../TimberUi/TimberUi/CommonUi/DialogBoxElement.cs) | Base `VisualElement` for custom modals. `SetTitle`, `AddCloseButton`, `SetDialogSize`/`SetDialogPercentSize`, `Show`/`ShowAsync`. | `CommonUi/DialogBoxElement.cs` |
+| [`InputDialogBox`](../../TimberUi/TimberUi/CommonUi/InputDialogBox.cs) | Concrete string input dialog. Static factories `CreateString`/`CreateInteger`/`CreateFloat(ILoc)`. | `CommonUi/InputDialogBox.cs` |
+| [`IntegerInputDialogBox`](../../TimberUi/TimberUi/CommonUi/InputDialogBox.cs) | `int` input dialog. | `CommonUi/InputDialogBox.cs` |
+| [`FloatInputDialogBox`](../../TimberUi/TimberUi/CommonUi/InputDialogBox.cs) | `float` input dialog. | `CommonUi/InputDialogBox.cs` |
+| [`InputDialogBox<TInput,TValueType>`](../../TimberUi/TimberUi/CommonUi/InputDialogBox.cs) | Base class for typed input dialogs. `ShowAsync` returns `(bool Confirmed, TValueType? Value)`. | `CommonUi/InputDialogBox.cs` |
+| [`PromptDialogElement`](../../TimberUi/TimberUi/Services/Dialogs/PromptDialogElement.cs) | `DialogBoxElement` subclass used internally by `DialogService.PromptAsync`. Seldom used directly. | `Services/Dialogs/PromptDialogElement.cs` |
+| [`TimberUiDialogExtensions.ShowAsync`](../../TimberUi/TimberUi/Extensions/Dialog.cs) | Extension method on `DialogBoxShower`; low-level async wrapper returning `bool?`. | `Extensions/Dialog.cs` |

--- a/Docs/TimberUi/EntityPanelFragments.MD
+++ b/Docs/TimberUi/EntityPanelFragments.MD
@@ -36,7 +36,7 @@ The base class creates a `panel` field (an `EntityPanelFragmentElement`) before 
 
 | Method | When called | Responsibility |
 |---|---|---|
-| `InitializeFragment()` | Once, when the entity-panel UI is built | Sealed base implementation: creates `panel`, calls `InitializePanel()`, returns `panel`. Do **not** override this. |
+| `InitializeFragment()` | Once, when the entity-panel UI is built | Base implementation (not `virtual` — don't hide it): creates `panel`, calls `InitializePanel()`, returns `panel`. Do **not** override this. |
 | `InitializePanel()` | Once, when the entity-panel UI is built (called by `InitializeFragment`) | **Override this** to build the visual tree inside `panel`. Add labels, buttons, sliders, etc. |
 | `ShowFragment(BaseComponent entity)` | Each time the player selects an entity | Base resolves `T` via `entity.GetComponent<T>()`. If the entity has no `T`, returns early — panel visibility is unchanged. Sets `panel.Visible = true` when the component is found. Call `base.ShowFragment(entity)` if you override. |
 | `UpdateFragment()` | Called periodically by the game while a compatible entity is selected | Virtual no-op by default. Override to read the current state from `component` and update labels/controls. Guard with `if (component is null) return;`. |

--- a/Docs/TimberUi/EntityPanelFragments.MD
+++ b/Docs/TimberUi/EntityPanelFragments.MD
@@ -1,0 +1,361 @@
+# Entity Panel Fragments
+
+When a player clicks a building or character, Timberborn opens an **entity inspector panel** made up of stacked fragment sections. TimberUi makes it straightforward to add your own sections: extend `BaseEntityPanelFragment<T>`, build the content with the fluent UiBuilder DSL, and register the fragment in your configurator. This guide walks through each step.
+
+## 1. Write a fragment
+
+### Extend `BaseEntityPanelFragment<T>`
+
+`BaseEntityPanelFragment<T>` is an abstract class that implements Timberborn's `IEntityPanelFragment` lifecycle. The type parameter `T` is the `BaseComponent` your fragment inspects — typically a component that lives on the buildings or characters you want to show it for.
+
+```cs
+using TimberUi.CommonUi;
+
+public class StorageFragment(ILoc t) : BaseEntityPanelFragment<Inventory>
+{
+    Label _lblContents = null!;
+
+    protected override void InitializePanel()
+    {
+        var row = panel.AddRow();
+        row.AddGameLabel("Contents:".Bold()).SetMarginRight();
+        _lblContents = row.AddGameLabel("—");
+    }
+
+    public override void UpdateFragment()
+    {
+        if (component is null) { return; }
+        _lblContents.text = $"{component.AmountOf(GoodSpecId.Log)} logs";
+    }
+}
+```
+
+The base class creates a `panel` field (an `EntityPanelFragmentElement`) before calling `InitializePanel`, so it is always available when your override runs. `component` is populated by `ShowFragment` and cleared by `ClearFragment`.
+
+### Lifecycle methods
+
+| Method | When called | Responsibility |
+|---|---|---|
+| `InitializeFragment()` | Once, when the entity-panel UI is built | Sealed base implementation: creates `panel`, calls `InitializePanel()`, returns `panel`. Do **not** override this. |
+| `InitializePanel()` | Once, when the entity-panel UI is built (called by `InitializeFragment`) | **Override this** to build the visual tree inside `panel`. Add labels, buttons, sliders, etc. |
+| `ShowFragment(BaseComponent entity)` | Each time the player selects an entity | Base resolves `T` via `entity.GetComponent<T>()`. If the entity has no `T`, returns early — panel visibility is unchanged. Sets `panel.Visible = true` when the component is found. Call `base.ShowFragment(entity)` if you override. |
+| `UpdateFragment()` | Called periodically by the game while a compatible entity is selected | Virtual no-op by default. Override to read the current state from `component` and update labels/controls. Guard with `if (component is null) return;`. |
+| `ClearFragment()` | When the player deselects an entity | Base sets `panel.Visible = false` and nulls `component`. Override only if you need extra teardown, and always call `base.ClearFragment()`. |
+
+### Component resolution
+
+The base calls `entity.GetComponent<T>()` on the raw `BaseComponent` passed by the game. If the selected entity does not have a `T` component, `ShowFragment` returns early leaving the panel as-is (visibility is unchanged). Hiding is handled by `ClearFragment()` setting `panel.Visible = false` on deselect, and by the initial `Visible = false` default — so a fragment for `WaterTower` will silently do nothing when a beaver is selected.
+
+### The `panel` field
+
+`panel` is an `EntityPanelFragmentElement` — a `NineSliceVisualElement` styled as an `entity-sub-panel`. It is the root element returned to the game. Build all your content inside it.
+
+---
+
+## 2. Customize the container appearance
+
+### `EntityPanelFragmentElement`
+
+The panel is an `entity-sub-panel`-styled nine-slice box. Two properties control its visual state:
+
+```cs
+panel.Background = EntityPanelFragmentBackground.Blue;
+panel.Visible = false;   // hide/show via display-style (not opacity)
+```
+
+`Background` swaps a CSS class on the element. The default is `Green`. All available values:
+
+| `EntityPanelFragmentBackground` | Visual style |
+|---|---|
+| `Green` | Standard green panel (default) |
+| `Blue` | Blue panel |
+| `PurpleStriped` | Striped purple |
+| `PalePurple` | Solid pale purple |
+| `RedStriped` | Striped red |
+| `Frame` | Frame-only, no fill |
+
+Set the background inside `InitializePanel` (or in an object initializer):
+
+```cs
+protected override void InitializePanel()
+{
+    panel.Background = EntityPanelFragmentBackground.Blue;
+    panel.AddGameLabel("My content");
+}
+```
+
+`Visible = false` is the initial default. The base `ShowFragment` sets it to `true` when the component is found and returns early (leaving visibility unchanged) when the component is absent; the base `ClearFragment` sets it back to `false`.
+
+### Building content with the UiBuilder DSL
+
+Inside `InitializePanel`, use the chainable extension methods on `VisualElement` to assemble controls. Common patterns:
+
+```cs
+// A labelled row
+var row = panel.AddRow();
+row.AddGameLabel("Throughput:").SetMarginRight();
+_lblValue = row.AddGameLabel("0/s");
+
+// A slider
+_slider = panel.AddSliderInt(label: "Priority", values: new(0, 10, 5));
+_slider.RegisterChange(v => _priority = v);
+
+// Buttons
+var btns = panel.AddHorizontalContainer();
+btns.AddGameButton("Reset", onClick: Reset).SetMarginRight();
+btns.AddEntityFragmentButton("Boost", onClick: Boost, color: EntityFragmentButtonColor.Green);
+
+// Progress bar with text label
+var bar = panel.AddProgressBar().SetFlexGrow(1).SetColor(ProgressBarColor.Teal);
+_barLabel = bar.AddProgressLabel();
+```
+
+See [Building UI](./BuildingUi.MD) for the full builder catalog.
+
+> **Initialize complex controls.** Timberborn widgets such as sliders and dropdowns require `panel.Initialize(initializer)` (where `initializer` is an injected `VisualElementInitializer`) before they function. Call it once at the end of `InitializePanel`, after all controls have been added. Simple labels and buttons do not need it.
+
+```cs
+public class MyFragment(VisualElementInitializer initializer, DropdownItemsSetter dropdownSetter)
+    : BaseEntityPanelFragment<MyComponent>
+{
+    Dropdown _cbo = null!;
+
+    protected override void InitializePanel()
+    {
+        _cbo = panel.AddDropdown().AddChangeHandler((_, i) => _selected = i);
+        panel.Initialize(initializer);
+        _cbo.SetItems(dropdownSetter, ["Option A", "Option B", "Option C"]);
+    }
+}
+```
+
+---
+
+## 3. Register a fragment
+
+Fragments must be registered in your `Configurator` for the **Game** or **MapEditor** context (entity panels do not exist in the main menu).
+
+### Option A — attribute (simplest)
+
+If your configurator uses `GameAttributeConfigurator` (see [Dependency Injection](./DependencyInjection.MD)), add `[BindFragment]` to the fragment class:
+
+```cs
+[BindFragment]
+public class StorageFragment(ILoc t) : BaseEntityPanelFragment<Inventory>
+{
+    // ...
+}
+```
+
+The attribute configurator discovers the class at startup and calls `BindFragment<StorageFragment>()` automatically. No configurator code needed. If the class also implements `IEntityFragmentOrder`, `BindOrderedFragment` is called instead.
+
+### Option B — single fragment, one call
+
+When you are wiring fragments imperatively, `BindFragment<T>()` is a one-liner that registers the fragment as a singleton, wraps it in `EntityPanelFragmentProvider<T>`, and multibinds the provider into `EntityPanelModule`:
+
+```cs
+[Context("Game")]
+public class GameConfigs : Configurator
+{
+    public override void Configure()
+    {
+        this.BindFragment<StorageFragment>();
+    }
+}
+```
+
+The fragment is placed in the `Top` slot of the entity panel by default.
+
+### Option C — multiple fragments via a provider
+
+When you have several fragments to register, or want to control their position, derive a provider class from `EntityPanelFragmentProvider` and call `BindFragments<TProvider>()`. The provider's constructor parameters are the fragment instances; `BindFragments` automatically binds every parameter that implements `IEntityPanelFragment` as a singleton before registering the provider.
+
+```cs
+[Context("Game")]
+public class GameConfigs : Configurator
+{
+    // One public constructor, listing every fragment as a parameter.
+    public class FragmentsProvider(StorageFragment storage, StatusFragment status)
+        : EntityPanelFragmentProvider([storage, status]);
+
+    public override void Configure()
+    {
+        this.BindFragments<FragmentsProvider>();
+    }
+}
+```
+
+`BindFragments<T>()` requires the provider to have **exactly one public constructor that takes parameters**. All `IEntityPanelFragment` parameters are bound as singletons for you.
+
+The demo project uses this exact pattern to register both `DemoFragment` and all `ColorfulFragments`:
+
+```cs
+// TimberUiDemo/ModConfigs.cs (abridged)
+[Context("Game")]
+public class GameConfigs : Configurator
+{
+    public class FragmentsProvider(DemoFragment coord) : EntityPanelFragmentProvider([coord]);
+
+    public override void Configure()
+    {
+        this.BindFragments<FragmentsProvider>();
+        this.BindFragments<ColorfulFragmentsProvider>();
+    }
+}
+```
+
+### Fragment positions
+
+`EntityPanelFragmentProvider` places fragments at `Top` by default. To choose a different slot, wrap registrations in `EntityPanelRegistration` and pass them to the non-generic `EntityPanelFragmentProvider` constructor:
+
+```cs
+public class FragmentsProvider(StorageFragment storage, StatusFragment status)
+    : EntityPanelFragmentProvider(
+    [
+        new(storage, EntityPanelFragmentPosition.Top),
+        new(status,  EntityPanelFragmentPosition.Side),
+    ]);
+```
+
+Available positions:
+
+| `EntityPanelFragmentPosition` | Location in panel |
+|---|---|
+| `Top` | Main top section (default) |
+| `Middle` | Middle section |
+| `Bottom` | Below middle |
+| `Side` | Side panel |
+| `LeftHeader` | Left header strip (supports `Order`) |
+| `MiddleHeader` | Middle header strip |
+| `Diagnostic` | Diagnostic section |
+| `Footer` | Footer strip |
+
+> **Warning — `Order` is honored only for `LeftHeader`.** The `Order` field on `EntityPanelRegistration` is forwarded to the builder only for `LeftHeader`; for every other position it is silently ignored. To control ordering for fragments in other positions, implement `IEntityFragmentOrder` and register with `BindOrderedFragment` / `BindFragmentOrder` (handled by `EntityFragmentOrderService`).
+
+---
+
+## 4. Control fragment ordering
+
+By default, the game orders fragments in the sequence they were registered. To guarantee that your fragment appears above or below the vanilla fragments — regardless of registration order — implement `IEntityFragmentOrder` on the fragment and register it with `BindOrderedFragment`.
+
+### Implement `IEntityFragmentOrder`
+
+```cs
+[BindFragment]                       // attribute path auto-promotes to BindOrderedFragment
+public class PriorityFragment : BaseEntityPanelFragment<MyComponent>, IEntityFragmentOrder
+{
+    // A negative Order floats the fragment to the top (above vanilla fragments).
+    // A positive Order sinks it to the bottom.
+    // Zero does nothing.
+    public int Order => -10;
+
+    // Return the root VisualElement that EntityFragmentOrderService will reposition.
+    public VisualElement Fragment => panel;
+
+    protected override void InitializePanel() { /* ... */ }
+}
+```
+
+### Register with the imperative helpers
+
+When not using attributes, use `BindOrderedFragment<T>()` in place of `BindFragment<T>()`:
+
+```cs
+public override void Configure()
+{
+    this.BindOrderedFragment<PriorityFragment>();
+}
+```
+
+`BindOrderedFragment<T>()` calls `BindFragment<T>()` and then `BindFragmentOrder<T>()` in one step.
+
+If you already registered the fragment via `BindFragments<TProvider>()` and only want to add ordering separately:
+
+```cs
+this.BindFragments<FragmentsProvider>();
+this.BindFragmentOrder<PriorityFragment>();  // adds it to the IEntityFragmentOrder multibinding
+```
+
+### How ordering works
+
+`EntityFragmentOrderService` (`[BindSingleton(Contexts = NonMenu)]`) collects all `IEntityFragmentOrder` registrations at load time, sorts them by `Order`, then repositions their `Fragment` elements:
+
+- **Negative order** — inserted before all non-ordered fragments (more negative = higher up).
+- **Positive order** — appended after all non-ordered fragments (more positive = lower down).
+- **Zero** — no repositioning; equivalent to not implementing the interface.
+
+Among fragments with the same `Order` value, relative ordering is determined by the sort's tie-breaking, which is unspecified — assign distinct values if you need a guaranteed sequence.
+
+---
+
+## 5. Complete example
+
+The following mirrors the `DemoFragment` + `ColorfulFragmentsProvider` pattern from the demo project.
+
+```cs
+// MyFragment.cs
+public class MyFragment(VisualElementInitializer initializer)
+    : BaseEntityPanelFragment<BlockObject>
+{
+    Label _lblCoords = null!;
+
+    protected override void InitializePanel()
+    {
+        panel.Background = EntityPanelFragmentBackground.Green;
+
+        var row = panel.AddRow();
+        row.AddGameLabel("Position:".Bold()).SetMarginRight();
+        _lblCoords = row.AddGameLabel("—");
+
+        panel.Initialize(initializer);
+    }
+
+    public override void UpdateFragment()
+    {
+        if (component is null) { return; }
+        var c = component.Coordinates;
+        _lblCoords.text = $"({c.x}, {c.y}, {c.z})";
+    }
+}
+
+// ModConfigs.cs
+[Context("Game")]
+public class GameConfigs : Configurator
+{
+    public class FragmentsProvider(MyFragment coords)
+        : EntityPanelFragmentProvider([coords]);
+
+    public override void Configure()
+    {
+        this.BindFragments<FragmentsProvider>();
+    }
+}
+```
+
+---
+
+## Key types
+
+| Type | Role | Source |
+|---|---|---|
+| `BaseEntityPanelFragment<T>` | Abstract base for fragments; lifecycle, component resolution, panel creation. | [`../../TimberUi/TimberUi/CommonUi/DefaultEntityPanelFragment.cs`](../../TimberUi/TimberUi/CommonUi/DefaultEntityPanelFragment.cs) |
+| `EntityPanelFragmentElement` | `NineSliceVisualElement` container; `Background` + `Visible`. | [`../../TimberUi/TimberUi/CommonUi/EntityPanelFragmentElement.cs`](../../TimberUi/TimberUi/CommonUi/EntityPanelFragmentElement.cs) |
+| `EntityPanelFragmentBackground` | Enum of visual styles for the panel container. | [`../../TimberUi/TimberUi/CommonUi/EntityPanelFragmentElement.cs`](../../TimberUi/TimberUi/CommonUi/EntityPanelFragmentElement.cs) |
+| `EntityPanelFragmentProvider` | `IProvider<EntityPanelModule>` that registers one or more fragments with the game. | [`../../TimberUi/TimberUi/CommonProviders/EntityPanelFragmentProvider.cs`](../../TimberUi/TimberUi/CommonProviders/EntityPanelFragmentProvider.cs) |
+| `EntityPanelRegistration` | `readonly record struct(Fragment, Position, Order)` used to configure per-fragment position. | [`../../TimberUi/TimberUi/CommonProviders/EntityPanelFragmentProvider.cs`](../../TimberUi/TimberUi/CommonProviders/EntityPanelFragmentProvider.cs) |
+| `EntityPanelFragmentPosition` | Enum of slots in the entity panel (Top, Middle, Bottom, Side, …). | [`../../TimberUi/TimberUi/CommonProviders/EntityPanelFragmentProvider.cs`](../../TimberUi/TimberUi/CommonProviders/EntityPanelFragmentProvider.cs) |
+| `[BindFragment]` | Attribute that auto-registers a fragment when using `AttributeConfigurator` bases. | [`../../TimberUi/TimberUi/DIAttributes/BindHelpers.cs`](../../TimberUi/TimberUi/DIAttributes/BindHelpers.cs) |
+| `BindFragment<T>()` | Configurator extension: register one fragment as a singleton + multibind. | [`../../TimberUi/TimberUi/Extensions/Configurators.cs`](../../TimberUi/TimberUi/Extensions/Configurators.cs) |
+| `BindFragments<TProvider>()` | Configurator extension: register a multi-fragment provider; auto-binds all `IEntityPanelFragment` ctor params. | [`../../TimberUi/TimberUi/Extensions/Configurators.cs`](../../TimberUi/TimberUi/Extensions/Configurators.cs) |
+| `BindOrderedFragment<T>()` | Configurator extension: `BindFragment` + `BindFragmentOrder` in one call. | [`../../TimberUi/TimberUi/Extensions/Configurators.cs`](../../TimberUi/TimberUi/Extensions/Configurators.cs) |
+| `BindFragmentOrder<T>()` | Configurator extension: adds an `IEntityFragmentOrder` to the multibinding only. | [`../../TimberUi/TimberUi/Extensions/Configurators.cs`](../../TimberUi/TimberUi/Extensions/Configurators.cs) |
+| `IEntityFragmentOrder` | Interface for ordering: `int Order` + `VisualElement Fragment`. | [`../../TimberUi/TimberUi/Services/EntityPanelOrder/IEntityFragmentOrder.cs`](../../TimberUi/TimberUi/Services/EntityPanelOrder/IEntityFragmentOrder.cs) |
+| `EntityFragmentOrderService` | Singleton that repositions ordered fragments after the panel is constructed. | [`../../TimberUi/TimberUi/Services/EntityPanelOrder/EntityFragmentOrderService.cs`](../../TimberUi/TimberUi/Services/EntityPanelOrder/EntityFragmentOrderService.cs) |
+
+### Demo
+
+| File | What it shows |
+|---|---|
+| [`../../TimberUi/TimberUiDemo/UI/DemoFragment.cs`](../../TimberUi/TimberUiDemo/UI/DemoFragment.cs) | Full `IEntityPanelFragment` implementation: labels, buttons, slider, dropdown, progress bars, formatted text. |
+| [`../../TimberUi/TimberUiDemo/UI/ColorfulFragments.cs`](../../TimberUi/TimberUiDemo/UI/ColorfulFragments.cs) | Six concrete fragments (one per `EntityPanelFragmentBackground` value) and a multi-fragment `ColorfulFragmentsProvider`. |
+| [`../../TimberUi/TimberUiDemo/ModConfigs.cs`](../../TimberUi/TimberUiDemo/ModConfigs.cs) | `FragmentsProvider` pattern and `BindFragments<T>()` calls in a `[Context("Game")]` configurator. |

--- a/Docs/TimberUi/HudAndMenus.MD
+++ b/Docs/TimberUi/HudAndMenus.MD
@@ -1,0 +1,201 @@
+# HUD & Main-Menu Injection
+
+Timberborn exposes two high-visibility injection points that mods commonly use to surface persistent controls: the **top-right HUD** (the row of icon buttons in the upper-right corner of the game screen) and the **main-menu button column** (the vertical list of buttons on the title screen). Both are claimed from a DI-bound service class that implements `ILoadableSingleton` and does the injection work inside `Load()`.
+
+- **Top-right HUD** — inject `UILayout` (a Timberborn game type), build a `NineSliceButton`, and call `layout.AddTopRight(element, order)`.
+- **Main-menu column** — inject `MainMenuPanel` (a Timberborn game type), use the TimberUi query helpers to locate the exit button, then use `AddMenuButton(...).InsertSelfAfter(...)` to splice your button into the list.
+
+Neither approach requires a UXML asset or a custom `VisualTreeAsset`. Both injection points persist for the lifetime of their scene — `ILoadableSingleton.Load` is called once per scene load.
+
+---
+
+## 1. Adding a top-right HUD item
+
+The top-right HUD is a row of clickable icon-buttons. `UILayout.AddTopRight(element, order)` appends any `VisualElement` to that row; the `order` parameter controls its position relative to other items (lower numbers appear earlier in the row).
+
+The standard pattern from the demo is:
+
+1. Inject `UILayout`.
+2. Create a `NineSliceButton` and apply the `top-right-item` class plus a `square-large--*` color class.
+3. Add a child `Label` for live text.
+4. Wire `clicked +=` to a handler.
+5. Call `layout.AddTopRight(item, order)`.
+
+### Example
+
+```cs
+// GameService.cs
+using UnityEngine.UIElements;
+using TimberUi;
+using UiBuilder;
+
+public class GameService(UILayout layout) : ILoadableSingleton
+{
+    int _counter;
+    Label _topBarLabel = null!;
+
+    public void Load()
+    {
+        AddTopBarItem();
+    }
+
+    void AddTopBarItem()
+    {
+        // Build the button: top-right-item sizes the container;
+        // square-large--green applies the nine-slice green background.
+        var item = new NineSliceButton()
+            .AddClasses([UiCssClasses.TopRightItemClass,
+                         UiCssClasses.ButtonTopBarPrefix + UiCssClasses.Green]);
+
+        item.style.justifyContent = Justify.Center;
+
+        item.clicked += OnTopBarItemClicked;
+
+        // AddLabel creates a child Label; AddLabelClasses applies game text styling.
+        _topBarLabel = item.AddLabel("Hello TimberUi")
+            .AddLabelClasses(GameLabelStyle.Game, color: GameLabelColor.Yellow);
+
+        // order 7 — adjust to taste; lower numbers sit closer to the left of the row.
+        layout.AddTopRight(item, 7);
+    }
+
+    void OnTopBarItemClicked()
+    {
+        _topBarLabel.text = $"Clicked: {++_counter} times.";
+    }
+}
+```
+
+Key CSS constants (all on `UiCssClasses`):
+
+| Constant | Value | Purpose |
+|---|---|---|
+| `TopRightItemClass` | `"top-right-item"` | Sizes and positions the item in the HUD row. |
+| `ButtonTopBarPrefix` | `"square-large--"` | Prefix for the color class. Concatenate with a color constant. |
+| `Green` | `"green"` | Produces `"square-large--green"`, the green nine-slice background. |
+| `Brown` | `"brown"` | Produces `"square-large--brown"`, the brown nine-slice background. |
+
+`AddLabel` and `AddLabelClasses` come from the TimberUi `UiBuilderExtensions` (see [Building UI with the UiBuilder DSL](./BuildingUi.MD)).
+
+### Binding
+
+```cs
+// ModConfigs.cs
+[Context("Game")]
+public class GameConfigs : Configurator
+{
+    public override void Configure()
+    {
+        Bind<GameService>().AsSingleton();
+    }
+}
+```
+
+`[Context("Game")]` scopes the binding to the in-game scene. Because `GameService` implements `ILoadableSingleton`, the container calls `Load()` automatically after the scene is ready. Registering as a singleton ensures a single instance manages the HUD item for the lifetime of the session.
+
+---
+
+## 2. Injecting a main-menu button
+
+The main-menu button column is a `NineSliceVisualElement` inside `MainMenuPanel`. TimberUi's query helpers on `MainMenuPanel` give you a typed reference to any existing button, and `InsertSelfAfter` / `InsertSelfBefore` let you splice a new button into the list relative to an existing one.
+
+### Example
+
+```cs
+// MenuService.cs
+using UnityEngine.UIElements;
+
+public class MenuService(MainMenuPanel menu) : ILoadableSingleton
+{
+    public void Load()
+    {
+        // Locate the existing "Exit Game" button in the menu hierarchy.
+        var exitButton = menu.GetExitGameButton();
+
+        // AddMenuButton builds a NineSliceButton with menu-button styling
+        // (initially parented under exitButton); InsertSelfAfter then splices
+        // it into the column immediately after exitButton.
+        exitButton
+            .AddMenuButton("Show demo dialog", ShowDemoDialog,
+                           name: "ShowDemoDialog",
+                           stretched: true)
+            .InsertSelfAfter(exitButton);
+    }
+
+    void ShowDemoDialog()
+    {
+        // ... open your dialog here
+    }
+}
+```
+
+`GetExitGameButton()` returns the `LocalizableButton` named `"ExitButton"` inside the menu's root. `AddMenuButton` builds the new button (initially as a child of the exit button), and `InsertSelfAfter(exitButton)` moves it into the column immediately after the exit button. TimberUi also provides `GetMainMenuPanel()`, which returns the `NineSliceVisualElement` named `"MainMenuPanel"` — the column container itself — if you prefer to add buttons to the column directly.
+
+`AddMenuButton` is a `VisualElement` extension that creates a `NineSliceButton` with `menu-button` styling. The `stretched: true` parameter adds the `menu-button--stretched` modifier, which makes the button fill the full column width, matching the style of the built-in main-menu buttons.
+
+### Binding
+
+```cs
+// ModConfigs.cs
+[Context("MainMenu")]
+public class MainMenuConfigs : Configurator
+{
+    public override void Configure()
+    {
+        Bind<MenuService>().AsSingleton();
+    }
+}
+```
+
+`[Context("MainMenu")]` scopes the binding to the title-screen scene. As with the game context, `ILoadableSingleton.Load` is called once after the scene is ready.
+
+### Positioning variants
+
+| Method | Effect |
+|---|---|
+| `.InsertSelfAfter(target)` | Places the new element immediately **below** `target` in the column. |
+| `.InsertSelfBefore(target)` | Places the new element immediately **above** `target` in the column. |
+
+Both are `VisualElement` extensions from TimberUi's `Childrens.cs`. They locate the parent of `target`, find its index, and insert the new element immediately before or after it.
+
+---
+
+## 3. `TopBarButton` vs. a raw `NineSliceButton` in `UILayout`
+
+TimberUi offers two ways to put a styled button in the top-right area:
+
+| Approach | When to use |
+|---|---|
+| **`TopBarButton`** (from `TimberUi.CommonUi`) | When you want a self-contained `NineSliceButton` subclass where the background (`TopBarButtonBackground.Green` or `.Brown`) is managed through a typed property and can be toggled at runtime to reflect state. The class handles adding and removing the `square-large--*` class for you. See [Alerts and Bars](./AlertsAndBars.MD#4-top-bar-buttons). |
+| **Raw `NineSliceButton` + `UILayout.AddTopRight`** | When you need to embed child elements (such as a live `Label`) inside the button, or when you need direct control over the full visual tree. You apply `UiCssClasses.TopRightItemClass` and `UiCssClasses.ButtonTopBarPrefix + UiCssClasses.Green` manually, just as `GameService` does. |
+
+Both approaches call `layout.AddTopRight(element, order)` to register the element with the HUD row. The difference is only in how the button itself is constructed and styled.
+
+Use `TopBarButton` for a simple clickable icon whose background might change. Use a raw `NineSliceButton` with child elements when the item is compositional — for example, a button that displays a counter or a status label inside its bounds.
+
+---
+
+## Key types
+
+| Type / Member | Role | Source |
+|---|---|---|
+| `UILayout` | Timberborn game type. `AddTopRight(element, order)` adds an element to the top-right HUD row. | Timberborn game assembly |
+| `MainMenuPanel` | Timberborn game type. Root panel for the title-screen UI. | Timberborn game assembly |
+| `GetMainMenuPanel()` | Extension on `MainMenuPanel`. Returns the `NineSliceVisualElement` named `"MainMenuPanel"` — the button column container. | [`../../TimberUi/TimberUi/Extensions/Queries.cs`](../../TimberUi/TimberUi/Extensions/Queries.cs) |
+| `GetExitGameButton()` | Extension on `MainMenuPanel`. Returns the `LocalizableButton` named `"ExitButton"`. | [`../../TimberUi/TimberUi/Extensions/Queries.cs`](../../TimberUi/TimberUi/Extensions/Queries.cs) |
+| `AddMenuButton(...)` | `VisualElement` extension. Creates a `NineSliceButton` with `menu-button` styling; optional `stretched`, `size`, `name`. | [`../../TimberUi/TimberUi/Extensions/Buttons.cs`](../../TimberUi/TimberUi/Extensions/Buttons.cs) |
+| `InsertSelfAfter(target)` | `VisualElement` extension. Inserts the element immediately after `target` in the parent's child list. | [`../../TimberUi/TimberUi/Extensions/Childrens.cs`](../../TimberUi/TimberUi/Extensions/Childrens.cs) |
+| `InsertSelfBefore(target)` | `VisualElement` extension. Inserts the element immediately before `target` in the parent's child list. | [`../../TimberUi/TimberUi/Extensions/Childrens.cs`](../../TimberUi/TimberUi/Extensions/Childrens.cs) |
+| `UiCssClasses.TopRightItemClass` | `"top-right-item"` — required class for HUD row items. | [`../../TimberUi/TimberUi/UiCssClasses.cs`](../../TimberUi/TimberUi/UiCssClasses.cs) |
+| `UiCssClasses.ButtonTopBarPrefix` | `"square-large--"` — prefix for the color class on top-bar buttons. | [`../../TimberUi/TimberUi/UiCssClasses.cs`](../../TimberUi/TimberUi/UiCssClasses.cs) |
+| `AddLabelClasses(style, color)` | Extension on `TextElement`. Applies game text CSS classes to a label in place. | [`../../TimberUi/TimberUi/Extensions/Properties.cs`](../../TimberUi/TimberUi/Extensions/Properties.cs) |
+| `TopBarButton` | `NineSliceButton` subclass with a typed `Background` property (Green/Brown). Alternative to a raw button. | [`../../TimberUi/TimberUi/CommonUi/TopBarButton.cs`](../../TimberUi/TimberUi/CommonUi/TopBarButton.cs) |
+| `ILoadableSingleton` | Timberborn contract. `Load()` is called once after the scene is ready. Implement on your service to hook injection timing. | Timberborn game assembly |
+
+### Demo
+
+| File | What it shows |
+|---|---|
+| [`../../TimberUi/TimberUiDemo/Services/GameService.cs`](../../TimberUi/TimberUiDemo/Services/GameService.cs) | Full HUD item: `NineSliceButton`, CSS classes, `AddLabel`, `AddLabelClasses`, `layout.AddTopRight`, live counter in `clicked +=`. |
+| [`../../TimberUi/TimberUiDemo/Services/MenuService.cs`](../../TimberUi/TimberUiDemo/Services/MenuService.cs) | Full menu injection: `GetExitGameButton()`, `AddMenuButton(..., stretched: true)`, `InsertSelfAfter`. |
+| [`../../TimberUi/TimberUiDemo/ModConfigs.cs`](../../TimberUi/TimberUiDemo/ModConfigs.cs) | `[Context("Game")]` binding for `GameService`; `[Context("MainMenu")]` binding for `MenuService`. |

--- a/Docs/TimberUi/HudAndMenus.MD
+++ b/Docs/TimberUi/HudAndMenus.MD
@@ -11,7 +11,7 @@ Neither approach requires a UXML asset or a custom `VisualTreeAsset`. Both injec
 
 ## 1. Adding a top-right HUD item
 
-The top-right HUD is a row of clickable icon-buttons. `UILayout.AddTopRight(element, order)` appends any `VisualElement` to that row; the `order` parameter controls its position relative to other items (lower numbers appear earlier in the row).
+The top-right HUD is a row of clickable icon-buttons. `UILayout.AddTopRight(element, order)` appends any `VisualElement` to that row; the `order` parameter controls its position relative to other items (the exact left/right meaning is defined by the game's `UILayout`).
 
 The standard pattern from the demo is:
 
@@ -55,7 +55,7 @@ public class GameService(UILayout layout) : ILoadableSingleton
         _topBarLabel = item.AddLabel("Hello TimberUi")
             .AddLabelClasses(GameLabelStyle.Game, color: GameLabelColor.Yellow);
 
-        // order 7 — adjust to taste; lower numbers sit closer to the left of the row.
+        // order 7 — adjust to taste; sets this item's position among other top-right items.
         layout.AddTopRight(item, 7);
     }
 
@@ -75,7 +75,7 @@ Key CSS constants (all on `UiCssClasses`):
 | `Green` | `"green"` | Produces `"square-large--green"`, the green nine-slice background. |
 | `Brown` | `"brown"` | Produces `"square-large--brown"`, the brown nine-slice background. |
 
-`AddLabel` and `AddLabelClasses` come from the TimberUi `UiBuilderExtensions` (see [Building UI with the UiBuilder DSL](./BuildingUi.MD)).
+`AddLabel` and `AddLabelClasses` are TimberUi extension methods declared in the `UnityEngine.UIElements` namespace — that is why `using UnityEngine.UIElements;` brings them into scope (`using TimberUi;` does not). See [Building UI with the UiBuilder DSL](./BuildingUi.MD).
 
 ### Binding
 
@@ -129,7 +129,7 @@ public class MenuService(MainMenuPanel menu) : ILoadableSingleton
 }
 ```
 
-`GetExitGameButton()` returns the `LocalizableButton` named `"ExitButton"` inside the menu's root. `AddMenuButton` builds the new button (initially as a child of the exit button), and `InsertSelfAfter(exitButton)` moves it into the column immediately after the exit button. TimberUi also provides `GetMainMenuPanel()`, which returns the `NineSliceVisualElement` named `"MainMenuPanel"` — the column container itself — if you prefer to add buttons to the column directly.
+`GetExitGameButton()` returns the `LocalizableButton` named `"ExitButton"` inside the menu's root. `AddMenuButton` builds the new button (initially as a child of the exit button), and `InsertSelfAfter(exitButton)` moves it into the column immediately after the exit button. TimberUi also provides `GetMainMenuPanel()`, which returns the panel's root container (the `NineSliceVisualElement` named `"MainMenuPanel"`) — handy as a query root, though the demo's sibling-insert against the exit button is the proven way to land a button in the column.
 
 `AddMenuButton` is a `VisualElement` extension that creates a `NineSliceButton` with `menu-button` styling. The `stretched: true` parameter adds the `menu-button--stretched` modifier, which makes the button fill the full column width, matching the style of the built-in main-menu buttons.
 

--- a/Docs/TimberUi/OptionalServices.MD
+++ b/Docs/TimberUi/OptionalServices.MD
@@ -1,0 +1,371 @@
+# Optional Services
+
+Some TimberUi features are genuinely opt-in: they depend on game subsystems that not every mod needs, require a specific DI context to function, or must be shared safely across multiple mods that might all want the same service. Rather than registering these services unconditionally, TimberUi exposes them through a family of **`TryBinding*` helper methods** on `Configurator`. Call them from your configurator's `Configure()` override and get the services injected wherever you need them.
+
+**Relevant source:** [`../../TimberUi/TimberUi/Extensions/OptionalServices.cs`](../../TimberUi/TimberUi/Extensions/OptionalServices.cs)
+
+---
+
+## The opt-in pattern
+
+All `TryBinding*` methods are extension methods on `Configurator` (namespace `Bindito.Core`), so they appear directly inside any `Configure()` override. Every `TryBinding*` method is **idempotent**: if the service is already bound — by your own configurator or by another mod that ran first — the call is a no-op. You can therefore call these from multiple mods without coordination or double-bind errors.
+
+`BindAchievement<T>` is **not** part of the `TryBinding*` family and is **not idempotent** — it uses a multibind and adds an entry on every call. Calling it twice for the same type will double-register that achievement.
+
+The full set of opt-in helpers is:
+
+| Method | Context requirement | What it registers |
+|---|---|---|
+| `TryBindingCameraShake(bool isMenuContext)` | Any | Camera-shake driver and settings toggle |
+| `TryBindingModdableAudioClip()` | Intended for Bootstrapper (per XML docs) | WAV-file converter pipeline |
+| `TryBindingAudioClipManagement()` | Any | Runtime add/replace/remove of clips |
+| `TryBindingSystemFileDialogService()` | Any | Native OS open/save dialogs |
+| `TryBindingSpriteOperations()` | Intended for MainMenu (per XML docs) | Sprite resize/deserialisation utilities |
+| `BindAchievement<T>(bool bindSelf)` | Any | Achievement multibind registration (additive — not idempotent) |
+
+`ModUpdateService` and `NamedIconProvider` are registered automatically by TimberUi's own configurators (`[BindSingleton(Contexts = MainMenu)]` and `[BindSingleton(Contexts = All)]` respectively); you enable their features by implementing an interface or injecting the provider, not by calling a `TryBinding*` method.
+
+---
+
+## Camera shake
+
+### Enable
+
+Call `TryBindingCameraShake` from any configurator that has access to the game session. The `isMenuContext` parameter tells the helper whether it is running in the main-menu scene; the shake *driver* (`CameraShakeService`) is not useful on the menu and is skipped there.
+
+```cs
+[Context("Game")]
+public class MyModGameConfig : GameAttributeConfigurator
+{
+    public override void Configure()
+    {
+        base.Configure();
+        this.TryBindingCameraShake(isMenuContext: false);
+    }
+}
+```
+
+If you also run a menu configurator and want the settings toggle available there, call it again with `isMenuContext: true` — it will register only the setting service and skip the shake driver.
+
+```cs
+[Context("MainMenu")]
+public class MyModMenuConfig : MainMenuAttributeConfigurator
+{
+    public override void Configure()
+    {
+        base.Configure();
+        this.TryBindingCameraShake(isMenuContext: true);
+    }
+}
+```
+
+### Use — `CameraShakeService`
+
+Inject `CameraShakeService` into any game-scene singleton or component and call `Shake` when something impactful happens. Chain `MoveTo` before `Shake` to centre the camera on the object of interest first.
+
+```cs
+public class ExplosionHandler(CameraShakeService cameraShake)
+{
+    public void OnExplosion(SelectableObject source)
+    {
+        cameraShake
+            .MoveTo(source)          // centres camera, then:
+            .Shake(duration: 0.4f, strength: 1.5f);
+    }
+}
+```
+
+`Shake(float duration, float strength)` — `duration` is in seconds (uses `Time.unscaledDeltaTime`, so it runs even while paused); `strength` maps linearly to amplitude (`0.05 × strength`). Both `MoveTo` and `Shake` are silently suppressed when the player has disabled camera shake in settings.
+
+`StopShaking()` is public if you need to cancel an in-progress shake early.
+
+### Player setting — `CameraShakeSettingService`
+
+`CameraShakeSettingService` is registered by the same `TryBindingCameraShake` call. It automatically injects a **"Disable camera shake"** toggle into the game's settings panel (placed after the UI scale row). You do not need to interact with it directly; it surfaces to the player automatically.
+
+If your mod needs to read or respond to the player's preference programmatically, inject it directly:
+
+```cs
+public class MyConditionalService(CameraShakeSettingService shakeSetting)
+{
+    void OnSomething()
+    {
+        if (!shakeSetting.IsDisabled)
+        {
+            // shake is allowed
+        }
+    }
+}
+```
+
+Subscribe to `OnCameraShakeDisabledChanged` to react at the moment the player flips the toggle.
+
+**Source:** [`../../TimberUi/TimberUi/Services/CameraShake/CameraShakeService.cs`](../../TimberUi/TimberUi/Services/CameraShake/CameraShakeService.cs), [`../../TimberUi/TimberUi/Services/CameraShake/CameraShakeSettingService.cs`](../../TimberUi/TimberUi/Services/CameraShake/CameraShakeSettingService.cs)
+
+---
+
+## Mod audio clips
+
+TimberUi's audio support comes in two complementary parts: a file-converter pipeline that loads `.wav` files from mod folders automatically, and a runtime service for registering or replacing clips in code.
+
+### Enable — file-conversion pipeline (`TryBindingModdableAudioClip`)
+
+Register `ModAudioClipConverter` during the **Bootstrapper** phase, before any mod assets are loaded. This is the context the file-converter pipeline is intended for (per its XML docs); calling it elsewhere is not a runtime error, but the pipeline assumes bootstrapper-phase lifecycle.
+
+```cs
+[Context("Bootstrapper")]
+public class MyModBootstrapConfig : BootstrapperAttributeConfigurator
+{
+    public override void Configure()
+    {
+        base.Configure();
+        this.TryBindingModdableAudioClip();
+    }
+}
+```
+
+Once registered, any `.wav` file found in your mod's file tree is decoded automatically and made available as a named `AudioClip` in the game's audio system. The clip's key in the audio service is the Unity `AudioClip.name` derived from the file.
+
+### Enable — runtime clip management (`TryBindingAudioClipManagement`)
+
+`AudioClipManagementService` does not depend on the bootstrapper pipeline — it can be registered in any context where you need to add, replace, or remove clips in code.
+
+```cs
+[Context("Game")]
+public class MyModGameConfig : GameAttributeConfigurator
+{
+    public override void Configure()
+    {
+        base.Configure();
+        this.TryBindingAudioClipManagement();
+    }
+}
+```
+
+### Use — `AudioClipManagementService`
+
+```cs
+public class MyAudioSetup(AudioClipManagementService audioClips)
+{
+    public void RegisterClips()
+    {
+        // Load a WAV from a known path and register it
+        audioClips.AddOrReplace("C:/MyMod/sounds/alarm.wav");
+
+        // Swap in a clip you already have a reference to
+        audioClips.AddOrReplace("Alarm", myExistingClip);
+
+        // Remove a clip that is no longer needed
+        audioClips.Remove("Alarm");
+
+        // Enumerate everything currently registered
+        foreach (var (name, clip) in audioClips.AllAudioClips)
+        {
+            // ...
+        }
+    }
+}
+```
+
+`AddOrReplace(string filePath, string? name = null)` loads the WAV file at `filePath` and registers it; the key used in the audio service is `AudioClip.name` as set by the loader. `AddOrReplace(string name, AudioClip clip)` lets you supply both the key and the clip directly. Only `.wav` files are supported; `AddOrReplace` calls the WAV loader directly and propagates whatever exception it throws on a corrupt or unreadable file. (`InvalidDataException` is thrown by the separate file-conversion pipeline in `ModAudioClipConverter`, not by `AddOrReplace` itself.)
+
+**Source:** [`../../TimberUi/TimberUi/Services/ModAudioClip/AudioClipManagementService.cs`](../../TimberUi/TimberUi/Services/ModAudioClip/AudioClipManagementService.cs), [`../../TimberUi/TimberUi/Services/ModAudioClip/ModAudioClipConverter.cs`](../../TimberUi/TimberUi/Services/ModAudioClip/ModAudioClipConverter.cs)
+
+---
+
+## Native file dialogs
+
+### Enable
+
+```cs
+[Context("Game")]
+public class MyModGameConfig : GameAttributeConfigurator
+{
+    public override void Configure()
+    {
+        base.Configure();
+        this.TryBindingSystemFileDialogService();
+    }
+}
+```
+
+The helper selects the correct implementation at runtime based on the operating system (Windows uses a P/Invoke against `comdlg32.dll`; Linux tries `zenity` then `kdialog`; macOS uses `osascript`). If you have already bound your own `ISystemFileDialogService` before this call, the call is a no-op and your implementation wins.
+
+> **Platform caveat:** Only the Windows implementation is tested. The Linux and macOS implementations are AI-generated and are explicitly marked untested in source. Both swallow internal errors — a failure at the OS dialog level will look like a user cancel (returning `null`) rather than throwing. On an unsupported platform, `TryBindingSystemFileDialogService` binds nothing and logs an error, so any attempt to inject `ISystemFileDialogService` will fail to resolve there.
+
+### Use — `ISystemFileDialogService`
+
+```cs
+public class MyExportHandler(ISystemFileDialogService fileDialog)
+{
+    public void ExportData()
+    {
+        // Prompt the user for a save location
+        var path = fileDialog.ShowSaveFileDialog(filter: ".json");
+        if (path is null) { return; } // user cancelled
+
+        File.WriteAllText(path, BuildJson());
+    }
+
+    public void ImportData()
+    {
+        // Prompt the user to pick a file to open
+        var path = fileDialog.ShowOpenFileDialog(filter: ".json;.txt");
+        if (path is null) { return; } // user cancelled
+
+        Process(File.ReadAllText(path));
+    }
+}
+```
+
+Both methods return `null` when the user cancels the dialog. The `filter` parameter is a semicolon-delimited list of extensions including the leading dot (e.g. `".json;.csv"`); pass `null` to show all files.
+
+**Source:** [`../../TimberUi/TimberUi/Services/SystemFileDialog/ISystemFileDialogService.cs`](../../TimberUi/TimberUi/Services/SystemFileDialog/ISystemFileDialogService.cs)
+
+---
+
+## Sprite operations
+
+### Enable
+
+`TryBindingSpriteOperations` registers the `SpriteOperationsConfigurator`, which provides utilities for resizing sprites and deserialising `Spec` types that contain `Sprite` fields. It is intended to be called from a **MainMenu** configurator (per its XML docs), as the sprite pipeline it sets up assumes main-menu loading phase; this is a convention the pipeline relies on, not a runtime-enforced constraint.
+
+```cs
+[Context("MainMenu")]
+public class MyModMenuConfig : MainMenuAttributeConfigurator
+{
+    public override void Configure()
+    {
+        base.Configure();
+        this.TryBindingSpriteOperations();
+    }
+}
+```
+
+Calling it more than once (or from multiple mods) is safe; subsequent calls are no-ops.
+
+**Source:** [`../../TimberUi/TimberUi/Extensions/OptionalServices.cs`](../../TimberUi/TimberUi/Extensions/OptionalServices.cs)
+
+---
+
+## Achievements
+
+`BindAchievement<T>` registers an `Achievement` subclass into TimberUi's multibind collection for achievements.
+
+### Enable and register
+
+```cs
+[Context("Game")]
+public class MyModGameConfig : GameAttributeConfigurator
+{
+    public override void Configure()
+    {
+        base.Configure();
+
+        // Register MyAchievement into the Achievement multibind only
+        this.BindAchievement<MyAchievement>();
+
+        // Also make MyAchievement directly injectable as itself
+        this.BindAchievement<MyAchievement>(bindSelf: true);
+    }
+}
+```
+
+When `bindSelf` is `false` (the default) the type is multi-bound as an `Achievement` but is not directly injectable. Pass `bindSelf: true` to also register it as a singleton under its own concrete type, which lets other services inject `MyAchievement` directly.
+
+**Source:** [`../../TimberUi/TimberUi/Extensions/OptionalServices.cs`](../../TimberUi/TimberUi/Extensions/OptionalServices.cs)
+
+---
+
+## Update notifications
+
+`ModUpdateService` is registered automatically by TimberUi's main-menu configurator (`[BindSingleton(Contexts = MainMenu)]`) — no `TryBinding*` call needed. You enable it for your mod by implementing `IModUpdateNotifier` and registering it as a multibind entry.
+
+### Implement `IModUpdateNotifier`
+
+```cs
+[MultiBind(typeof(IModUpdateNotifier))]
+public class MyModUpdateNotifier : IModUpdateNotifier
+{
+    // The mod id as it appears in your mod's manifest.json
+    public string ModId => "my.mod.id";
+
+    // The version string for this announcement
+    public string Version => "1.2.0";
+
+    // A localization key whose value contains your changelog text
+    public string MessageLocKey => "MyMod.Update.1_2_0";
+}
+```
+
+At main-menu load, `ModUpdateService` cross-references every bound `IModUpdateNotifier` against the list of enabled mods, skips any version the player has already dismissed, and shows a modal dialog for each remaining announcement. The dialog offers **Dismiss** (remembers the decision via `PlayerPrefs` — the dialog won't appear again for that version) and **Remind** (shows again next launch).
+
+The `Version` field versions the announcement, not the mod binary. Bumping it causes the dialog to re-appear even for players who are already on that mod version, so use it to distinguish distinct announcements rather than tracking binary releases.
+
+**Source:** [`../../TimberUi/TimberUi/Services/ModUpdate/IModUpdateNotifier.cs`](../../TimberUi/TimberUi/Services/ModUpdate/IModUpdateNotifier.cs), [`../../TimberUi/TimberUi/Services/ModUpdate/ModUpdateService.cs`](../../TimberUi/TimberUi/Services/ModUpdate/ModUpdateService.cs)
+
+---
+
+## Named icons
+
+`NamedIconProvider` is registered automatically by TimberUi's library configurators (`[BindSingleton(Contexts = All)]`) and is available in every game context. Inject it directly; no `TryBinding*` call is required.
+
+### Use
+
+```cs
+public class MyFragment(NamedIconProvider icons)
+{
+    public void BuildUi(VisualElement parent)
+    {
+        // Use a built-in named sprite
+        parent.AddImage(icons.Food);
+        parent.AddImage(icons.Science);
+        parent.AddImage(icons.QuestionMark);
+
+        // Load and cache a custom sprite by name and asset path
+        var myIcon = icons.GetOrLoad("MyCustomIcon", "sprites/mymod/my-icon");
+        parent.AddImage(myIcon);
+
+        // Shorthand helpers for common asset roots
+        var topbarSprite = icons.GetOrLoadTopbar("MyTopbar", "my-topbar-icon");
+        // resolves to: sprites/topbar/my-topbar-icon
+
+        var gameSprite = icons.GetOrLoadGameIcon("MyGameIcon", "my-game-icon");
+        // resolves to: ui/images/game/my-game-icon
+    }
+}
+```
+
+The built-in named properties are:
+
+| Property | Asset path |
+|---|---|
+| `Food` | `sprites/topbar/Food` |
+| `Logs` | `sprites/topbar/Logs` |
+| `Materials` | `sprites/topbar/Materials` |
+| `Science` | `sprites/topbar/Science` |
+| `Water` | `sprites/topbar/Water` |
+| `QuestionMark` | `ui/images/game/question-mark` |
+| `Clock` | `ui/images/game/production-icon` |
+| `Arrow` | `ui/images/game/Arrow` |
+| `ScienceAlt` | `ui/images/game/science-icon` |
+
+`GetOrLoad(name, path)` caches by both name and path, so the same asset loaded under different names is fetched from disk only once. Use the named properties or the `GetOrLoad*` helpers for first access; the indexer `provider["name"]` is a fast lookup but requires the sprite to have been loaded previously by a `GetOrLoad*` call.
+
+**Source:** [`../../TimberUi/TimberUi/Services/NamedIconProvider.cs`](../../TimberUi/TimberUi/Services/NamedIconProvider.cs)
+
+---
+
+## Key types
+
+| Type | Role | Source |
+|---|---|---|
+| `UiBuilderExtensions` (in `Bindito.Core`) | Hosts all `TryBinding*` helpers as extension methods on `Configurator` | [`../../TimberUi/TimberUi/Extensions/OptionalServices.cs`](../../TimberUi/TimberUi/Extensions/OptionalServices.cs) |
+| `CameraShakeService` | Per-frame camera jitter driver; `MoveTo` + `Shake` + `StopShaking` | [`../../TimberUi/TimberUi/Services/CameraShake/CameraShakeService.cs`](../../TimberUi/TimberUi/Services/CameraShake/CameraShakeService.cs) |
+| `CameraShakeSettingService` | Persisted on/off preference; injects settings-panel toggle automatically | [`../../TimberUi/TimberUi/Services/CameraShake/CameraShakeSettingService.cs`](../../TimberUi/TimberUi/Services/CameraShake/CameraShakeSettingService.cs) |
+| `ModAudioClipConverter` | Bootstrapper-phase `.wav` → `AudioClip` converter; lifecycle-manages created clips | [`../../TimberUi/TimberUi/Services/ModAudioClip/ModAudioClipConverter.cs`](../../TimberUi/TimberUi/Services/ModAudioClip/ModAudioClipConverter.cs) |
+| `AudioClipManagementService` | Runtime add/replace/remove of named clips in `AudioClipService` | [`../../TimberUi/TimberUi/Services/ModAudioClip/AudioClipManagementService.cs`](../../TimberUi/TimberUi/Services/ModAudioClip/AudioClipManagementService.cs) |
+| `ISystemFileDialogService` | Cross-platform open/save file dialog contract; `TryBinding` selects the OS implementation | [`../../TimberUi/TimberUi/Services/SystemFileDialog/ISystemFileDialogService.cs`](../../TimberUi/TimberUi/Services/SystemFileDialog/ISystemFileDialogService.cs) |
+| `IModUpdateNotifier` | Mod-implemented interface: `ModId`, `Version`, `MessageLocKey` | [`../../TimberUi/TimberUi/Services/ModUpdate/IModUpdateNotifier.cs`](../../TimberUi/TimberUi/Services/ModUpdate/IModUpdateNotifier.cs) |
+| `ModUpdateService` | Collects notifiers, deduplicates by `PlayerPrefs`, shows main-menu dialogs | [`../../TimberUi/TimberUi/Services/ModUpdate/ModUpdateService.cs`](../../TimberUi/TimberUi/Services/ModUpdate/ModUpdateService.cs) |
+| `NamedIconProvider` | Two-level sprite cache; named built-in properties + `GetOrLoad` / `GetOrLoadTopbar` / `GetOrLoadGameIcon` | [`../../TimberUi/TimberUi/Services/NamedIconProvider.cs`](../../TimberUi/TimberUi/Services/NamedIconProvider.cs) |

--- a/Docs/TimberUi/OptionalServices.MD
+++ b/Docs/TimberUi/OptionalServices.MD
@@ -191,7 +191,7 @@ public class MyModGameConfig : GameAttributeConfigurator
 
 The helper selects the correct implementation at runtime based on the operating system (Windows uses a P/Invoke against `comdlg32.dll`; Linux tries `zenity` then `kdialog`; macOS uses `osascript`). If you have already bound your own `ISystemFileDialogService` before this call, the call is a no-op and your implementation wins.
 
-> **Platform caveat:** Only the Windows implementation is tested. The Linux and macOS implementations are AI-generated and are explicitly marked untested in source. Both swallow internal errors — a failure at the OS dialog level will look like a user cancel (returning `null`) rather than throwing. On an unsupported platform, `TryBindingSystemFileDialogService` binds nothing and logs an error, so any attempt to inject `ISystemFileDialogService` will fail to resolve there.
+> **Platform caveat:** Only the Windows implementation is verified. The Linux and macOS implementations are marked untested in source — verify them before relying on file dialogs on those platforms. Both swallow internal errors, so an OS-level failure surfaces as a user cancel (returning `null`) rather than an exception. On an unsupported platform, `TryBindingSystemFileDialogService` binds nothing and logs an error, so any attempt to inject `ISystemFileDialogService` will fail to resolve there.
 
 ### Use — `ISystemFileDialogService`
 

--- a/Docs/TimberUi/PrefabDecorators.MD
+++ b/Docs/TimberUi/PrefabDecorators.MD
@@ -145,6 +145,16 @@ this.BindTemplateModule(h => h
 this.BindSingleton<WorkQuotaTracker>(); // bound separately as singleton
 ```
 
+When the subject or decorator type is only known at runtime, use the non-generic overload that takes `Type` arguments instead:
+
+```cs
+public TemplateModuleHelper AddDecorator(Type subject, Type decorator, bool addTransient = true)
+```
+
+```cs
+this.BindTemplateModule(h => h.AddDecorator(typeof(Workplace), myDecoratorType));
+```
+
 ### Two-call form
 
 When you need to conditionally add decorators before committing, obtain the helper explicitly and call `Bind()` yourself:
@@ -166,7 +176,7 @@ public override void Configure()
 }
 ```
 
-> **Call `Bind()` exactly once.** Each `Bind()` call registers a new `TemplateModule` provider. Calling it multiple times on the same helper — or calling `Bind()` on a helper obtained via the lambda form — would register duplicate modules. Prefer the lambda form to make it impossible to forget.
+> **Call `Bind()` exactly once.** Each `Bind()` call registers a new `TemplateModule` provider, so calling it twice on the same helper registers duplicate modules. The lambda form of `BindTemplateModule` calls `Bind()` for you (and never hands you the helper), so prefer it whenever you don't need the two-call form — it makes the mistake impossible.
 
 ### When to prefer the imperative path
 

--- a/Docs/TimberUi/PrefabDecorators.MD
+++ b/Docs/TimberUi/PrefabDecorators.MD
@@ -1,0 +1,268 @@
+# Decorating Game Prefabs with Template Modules
+
+Timberborn builds each in-game entity from a prefab **template**: a fixed list of component types assembled once at load time. A **template-module decorator** lets your mod inject an extra `BaseComponent` onto every entity that already carries a particular component — without touching any game prefab asset. This is how you bolt new behaviour onto stock buildings, workers, or resources entirely in code.
+
+This guide covers both registration paths — the zero-boilerplate attribute path and the fully-imperative path — and explains how they interact with Timberborn's four game contexts.
+
+**Relevant source:**
+- [`../../TimberUi/TimberUi/DIAttributes/AddTemplateModuleAttribute.cs`](../../TimberUi/TimberUi/DIAttributes/AddTemplateModuleAttribute.cs) — `[AddTemplateModule2]` and the obsolete `[AddTemplateModule]`
+- [`../../TimberUi/TimberUi/DIAttributes/AttributeBinder.cs`](../../TimberUi/TimberUi/DIAttributes/AttributeBinder.cs) — assembly scanning and decorator collection
+- [`../../TimberUi/TimberUi/Extensions/ConfiguratorHelpers.cs`](../../TimberUi/TimberUi/Extensions/ConfiguratorHelpers.cs) — `BindTemplateModule` extension methods on `Configurator`
+- [`../../TimberUi/TimberUi/Helpers/ConfiguratorHelpers.cs`](../../TimberUi/TimberUi/Helpers/ConfiguratorHelpers.cs) — `TemplateModuleHelper.AddDecorator`
+
+---
+
+## 1. How template-module decoration works
+
+When the game starts a session it calls every registered `TemplateModule` in sequence, each of which may call `AddDecorator<TSubject, TDecorator>()` on the template builder. The result is that every entity whose template contains `TSubject` also receives a freshly-instantiated `TDecorator` component. Decoration happens once at template-build time; the component is then present on every subsequent entity instance for the lifetime of the session.
+
+From your mod's perspective:
+
+1. Write a `BaseComponent` subclass — the **decorator** — that holds whatever state or logic you need.
+2. Tell TimberUi which existing game component type — the **subject** — should trigger its injection.
+3. Register the pair in a configurator for the **Game** context (or **MapEditor** if you also need it there).
+
+The decorator receives full constructor injection from the DI container, so you can inject services, `ILoc`, or any other registered type exactly as you would in any other component.
+
+> **Timberborn-provided types.** `BaseComponent`, `TemplateModule`, `Workplace`, `Dwelling`, and `Building` are all Timberborn game types, not TimberUi types. TimberUi provides only the registration plumbing described here.
+
+---
+
+## 2. The attribute path — `[AddTemplateModule2]`
+
+### Write the decorator
+
+```cs
+// Injects a work-quota tracker onto every Workplace entity.
+// Workplace is a Timberborn game component (not part of TimberUi).
+[AddTemplateModule2(typeof(Workplace))]
+public class WorkQuotaTracker(ILoc t) : BaseComponent
+{
+    int _dailyQuota;
+
+    public void SetQuota(int quota) => _dailyQuota = quota;
+
+    public int GetQuota() => _dailyQuota;
+}
+```
+
+That single attribute is all the registration code you need. When `AttributeConfigurator` scans your assembly it discovers the attribute, records the `(Workplace → WorkQuotaTracker)` pair, and at the end of the scan calls `BindTemplateModule` with all collected pairs in a single batch.
+
+### Attribute properties
+
+| Property | Type | Default | Meaning |
+|---|---|---|---|
+| `Subject` (constructor arg) | `Type` | required | The game component type whose presence triggers injection of the decorator |
+| `Contexts` | `BindAttributeContext` | `Game` | Which DI contexts this decoration is active in |
+| `AlsoBindTransient` | `bool` | `true` | Also bind the decorator class itself as transient so it can be resolved by other DI consumers |
+
+### Context filtering
+
+Template-module attributes are only processed in a **NonMenu** context (`Game | MapEditor` — the attribute scanner skips this code path entirely in `MainMenu` and `Bootstrapper`). The `Contexts` property then further restricts within NonMenu:
+
+- `Contexts = BindAttributeContext.Game` (default) — active in-game only; ignored in the map editor.
+- `Contexts = BindAttributeContext.MapEditor` — active in the map editor only; ignored in-game.
+- `Contexts = BindAttributeContext.NonMenu` — active in both the game and map-editor scenes.
+
+To attach your decorator in both scenes:
+
+```cs
+[AddTemplateModule2(typeof(Workplace), Contexts = BindAttributeContext.NonMenu)]
+public class WorkQuotaTracker(ILoc t) : BaseComponent
+{
+    // ...
+}
+```
+
+### Auto-discovery requirement
+
+`[AddTemplateModule2]` is only auto-discovered when your configurator inherits from `GameAttributeConfigurator` (or `MapEditorAttributeConfigurator`) and calls `base.Configure()` so the attribute scan runs. See [Dependency Injection](./DependencyInjection.MD) for the full configurator setup.
+
+```cs
+[Context("Game")]
+public class MyModGameConfig : GameAttributeConfigurator { }
+```
+
+No other code is needed — the empty subclass is sufficient.
+
+### `AlsoBindTransient`
+
+By default (`AlsoBindTransient = true`) the attribute scanner also calls `configurator.Bind(decoratorType).AsTransient()`, so other services can inject your decorator directly. If you are already binding the decorator type through a `[Bind…]` attribute or an explicit call in `Configure()`, set `AlsoBindTransient = false` to avoid the duplicate binding:
+
+```cs
+[BindSingleton]                                      // explicit binding
+[AddTemplateModule2(typeof(Workplace), AlsoBindTransient = false)]
+public class WorkQuotaTracker(ILoc t) : BaseComponent { /* ... */ }
+```
+
+---
+
+## 3. The imperative path — `BindTemplateModule`
+
+When attributes are not enough — conditional registration, types loaded at runtime, or mixing decorator wiring with other custom configurator logic — use the `BindTemplateModule` extension method on `Configurator`.
+
+### One-call lambda form (recommended)
+
+```cs
+[Context("Game")]
+public class MyModGameConfig : GameAttributeConfigurator
+{
+    public override void Configure()
+    {
+        base.Configure(); // attribute scan runs first
+
+        // Imperatively add an extra decorator that attributes cannot cover,
+        // for example because the condition depends on runtime configuration.
+        this.BindTemplateModule(h => h
+            .AddDecorator<Dwelling, DwellingCapacityTracker>()
+            .AddDecorator<Workplace, WorkQuotaTracker>()
+        );
+    }
+}
+```
+
+The lambda receives a `TemplateModuleHelper`, you call `AddDecorator` on it, return it, and `Bind()` is called for you automatically. The method itself returns `Configurator` so it chains with other calls.
+
+### `TemplateModuleHelper.AddDecorator<TSubject, TDecorator>`
+
+```cs
+public TemplateModuleHelper AddDecorator<TSubject, TDecorator>(bool addTransient = true)
+    where TDecorator : class
+```
+
+| Parameter | Default | Meaning |
+|---|---|---|
+| `TSubject` | — | The existing game component type to decorate |
+| `TDecorator` | — | Your `BaseComponent` subclass to inject |
+| `addTransient` | `true` | Also call `configurator.BindTransient<TDecorator>()` so the type is resolvable |
+
+Pass `addTransient: false` if you are binding the decorator type separately:
+
+```cs
+this.BindTemplateModule(h => h
+    .AddDecorator<Workplace, WorkQuotaTracker>(addTransient: false)
+);
+this.BindSingleton<WorkQuotaTracker>(); // bound separately as singleton
+```
+
+### Two-call form
+
+When you need to conditionally add decorators before committing, obtain the helper explicitly and call `Bind()` yourself:
+
+```cs
+public override void Configure()
+{
+    base.Configure();
+
+    var helper = this.BindTemplateModule();
+    helper.AddDecorator<Workplace, WorkQuotaTracker>();
+
+    if (SomeCondition)
+    {
+        helper.AddDecorator<Dwelling, DwellingCapacityTracker>();
+    }
+
+    helper.Bind(); // must be called exactly once
+}
+```
+
+> **Call `Bind()` exactly once.** Each `Bind()` call registers a new `TemplateModule` provider. Calling it multiple times on the same helper — or calling `Bind()` on a helper obtained via the lambda form — would register duplicate modules. Prefer the lambda form to make it impossible to forget.
+
+### When to prefer the imperative path
+
+- You need to register decorators conditionally (feature flags, mod-compatibility checks).
+- Your decorator type is determined at runtime.
+- You want to keep all configurator wiring in one place and not scatter `[AddTemplateModule2]` attributes across the codebase.
+- You need to mix decorator registration with other advanced wiring in the same `Configure()` override.
+
+---
+
+## 4. Complete worked example
+
+The following shows a small mod that tracks a custom "priority score" on every `Building` entity. The decorator is registered with the attribute and exposes a simple property that an entity-panel fragment can read.
+
+```cs
+// MyMod/Decorators/BuildingPriorityScore.cs
+
+/// <summary>
+/// Decorator attached to every Building entity. Holds the player-assigned
+/// priority score used by the mod's scheduling logic.
+/// </summary>
+/// <remarks>
+/// Building is a Timberborn game component. This class is injected by
+/// TimberUi's template-module mechanism — do not instantiate directly.
+/// </remarks>
+[AddTemplateModule2(typeof(Building))]
+public class BuildingPriorityScore : BaseComponent
+{
+    /// <summary>Gets or sets the priority score for this building (0–100).</summary>
+    public int Score { get; set; }
+}
+```
+
+```cs
+// MyMod/Configs/GameConfig.cs
+
+/// <summary>Game-context configurator. Auto-discovers [AddTemplateModule2] attributes.</summary>
+[Context("Game")]
+public class MyModGameConfig : GameAttributeConfigurator { }
+```
+
+At runtime, every entity that has a `Building` component will also receive a `BuildingPriorityScore` component. A fragment or service can retrieve it with `building.GetComponent<BuildingPriorityScore>()` (or via constructor injection if the decorator is resolved from the container directly).
+
+### Adding map-editor support
+
+If your mod has a map-editor configurator and the decorator should also be present there, change the attribute's `Contexts`:
+
+```cs
+[AddTemplateModule2(typeof(Building), Contexts = BindAttributeContext.NonMenu)]
+public class BuildingPriorityScore : BaseComponent { /* ... */ }
+```
+
+Then add the matching configurator:
+
+```cs
+[Context("MapEditor")]
+public class MyModMapEditorConfig : MapEditorAttributeConfigurator { }
+```
+
+---
+
+## 5. Migration from `[AddTemplateModule]`
+
+The original `[AddTemplateModule]` attribute is marked `[Obsolete]` and should not be used in new code. The behavioural difference is:
+
+| Attribute | When active |
+|---|---|
+| `[AddTemplateModule]` | Only when the active context is exactly `Game` (the `isGame` flag). |
+| `[AddTemplateModule2]` | Whenever the active context is `NonMenu` (`Game` or `MapEditor`), then filtered further by the attribute's own `Contexts` property. |
+
+To migrate, replace the attribute name and add an explicit `Contexts` if you need a context other than the default `Game`:
+
+```cs
+// Before (obsolete):
+[AddTemplateModule(typeof(Workplace))]
+public class WorkQuotaTracker : BaseComponent { /* ... */ }
+
+// After:
+[AddTemplateModule2(typeof(Workplace))]           // Contexts defaults to Game — same behaviour
+public class WorkQuotaTracker : BaseComponent { /* ... */ }
+```
+
+Both attributes share the same `AlsoBindTransient` property with the same default (`true`), so no change is needed there.
+
+---
+
+## Key types
+
+| Type | Role | Source |
+|---|---|---|
+| `[AddTemplateModule2]` | Primary attribute for template-module decorator registration; properties `Subject`, `Contexts`, `AlsoBindTransient`. | [`../../TimberUi/TimberUi/DIAttributes/AddTemplateModuleAttribute.cs`](../../TimberUi/TimberUi/DIAttributes/AddTemplateModuleAttribute.cs) |
+| `[AddTemplateModule]` | Obsolete predecessor; only active in the `Game` context; no `Contexts` property. | [`../../TimberUi/TimberUi/DIAttributes/AddTemplateModuleAttribute.cs`](../../TimberUi/TimberUi/DIAttributes/AddTemplateModuleAttribute.cs) |
+| `BindAttributeContext` | `[Flags]` enum: `None`, `MainMenu (1)`, `Game (2)`, `MapEditor (4)`, `Bootstrapper (8)`, `All` (excludes Bootstrapper), `NonMenu = Game \| MapEditor`. | [`../../TimberUi/TimberUi/DIAttributes/BindAttribute.cs`](../../TimberUi/TimberUi/DIAttributes/BindAttribute.cs) |
+| `AttributeBinder` | Static engine called by `AttributeConfigurator.Configure()`; collects all `[AddTemplateModule2]` entries and registers them via a single `BindTemplateModule` call. | [`../../TimberUi/TimberUi/DIAttributes/AttributeBinder.cs`](../../TimberUi/TimberUi/DIAttributes/AttributeBinder.cs) |
+| `TemplateModuleHelper` | Fluent builder; obtained via `configurator.BindTemplateModule()`; `AddDecorator<TSubject, TDecorator>(bool addTransient = true)` accumulates pairs; `Bind()` commits them. | [`../../TimberUi/TimberUi/Helpers/ConfiguratorHelpers.cs`](../../TimberUi/TimberUi/Helpers/ConfiguratorHelpers.cs) |
+| `BindTemplateModule(Func<…>)` | `Configurator` extension; passes a `TemplateModuleHelper` to a lambda and calls `Bind()` automatically. | [`../../TimberUi/TimberUi/Extensions/ConfiguratorHelpers.cs`](../../TimberUi/TimberUi/Extensions/ConfiguratorHelpers.cs) |
+| `BindTemplateModule()` | `Configurator` extension; returns a bare `TemplateModuleHelper` for the two-call form; caller must call `Bind()`. | [`../../TimberUi/TimberUi/Extensions/ConfiguratorHelpers.cs`](../../TimberUi/TimberUi/Extensions/ConfiguratorHelpers.cs) |
+| `GameAttributeConfigurator` | Base class for the Game-context configurator; `Configure()` runs the attribute scan. | [`../../TimberUi/TimberUi/AttributeConfigurator.cs`](../../TimberUi/TimberUi/AttributeConfigurator.cs) |
+| `MapEditorAttributeConfigurator` | Base class for the MapEditor-context configurator; same scan, different context flag. | [`../../TimberUi/TimberUi/AttributeConfigurator.cs`](../../TimberUi/TimberUi/AttributeConfigurator.cs) |

--- a/Docs/TimberUi/README.MD
+++ b/Docs/TimberUi/README.MD
@@ -55,9 +55,12 @@ See [Building UI](./BuildingUi.MD) for the full builder catalog.
 ## Guides
 
 - [Dependency Injection](./DependencyInjection.MD) — the `[Bind…]` attribute family, context filtering, and the imperative `Configurator` helpers for binding, multibinding, template modules, and rebinding game services.
+- [Decorating Game Prefabs](./PrefabDecorators.MD) — attach your own components to existing buildings/characters at template-build time via `[AddTemplateModule2]` and `BindTemplateModule`.
 - [Building UI](./BuildingUi.MD) — the fluent UiBuilder DSL: rows, labels, buttons, text/number fields, sliders, dropdowns, images, progress bars, rich text, and inline styling.
 - [Entity Panel Fragments](./EntityPanelFragments.MD) — add inspector panels to buildings and characters with `BaseEntityPanelFragment<T>`, choose their position, and control their order.
 - [Dialogs & Prompts](./DialogsAndPrompts.MD) — show alerts, confirmations, and text/number input dialogs with `DialogService` and the `DialogBoxElement` family.
 - [Alerts & Bars](./AlertsAndBars.MD) — register alert-panel fragments, bottom-bar modules, and top-bar buttons.
+- [HUD & Main-Menu Injection](./HudAndMenus.MD) — add a persistent item to the top-right HUD and splice a button into the main-menu column.
 - [Optional Services](./OptionalServices.MD) — opt-in services: camera shake, mod audio clips, native file dialogs, sprite operations, achievements, update notifications, and named icons.
 - [Utilities](./Utilities.MD) — WAV loading, serializable collections, localization and persistence helpers, text-to-texture rendering, the entity-select tool, and USS/UXML export.
+- [Developer Panel Tools](./DevTools.MD) — add a section to the in-game dev panel with `IDevModule`, dump the live UI tree, and wire a dev-mode toggle.

--- a/Docs/TimberUi/README.MD
+++ b/Docs/TimberUi/README.MD
@@ -46,7 +46,7 @@ Inside a fragment or dialog, assemble the visual tree with chainable `Add…`/`S
 ```cs
 var row = root.AddRow();
 row.AddLabel("Name").SetMarginRight();
-row.AddTextField(onValueChanged: OnNameChanged).SetFlexGrow();
+row.AddTextField(changeCallback: OnNameChanged).SetFlexGrow();
 row.AddButton("Save", onClick: Save, style: GameButtonStyle.Menu);
 ```
 

--- a/Docs/TimberUi/README.MD
+++ b/Docs/TimberUi/README.MD
@@ -1,0 +1,63 @@
+# TimberUi
+
+**TimberUi** is a foundation library for Timberborn mods that need a user interface. It layers two things on top of the game's own systems:
+
+1. An **attribute-driven dependency-injection layer** over Bindito — decorate a class with `[BindSingleton]`, `[MultiBind(...)]`, `[BindFragment]`, or `[AddTemplateModule2]` and a single per-context configurator wires it up automatically, instead of hand-writing `Bind<T>().AsSingleton()` for everything.
+2. A large **fluent UI-building DSL** plus ready-made controls (dialogs, sliders, dropdowns, entity-panel fragments, alerts, bottom-bar and top-bar buttons) that target Timberborn's existing visual style, so your UI looks native with very little CSS.
+
+Everything is **opt-in and incremental**: reference the assembly, register one configurator per game state, and use only the pieces you need. See [the Demo project](../../TimberUi/TimberUiDemo/) for runnable examples.
+
+## Getting started
+
+### 1. Depend on the library
+
+Add TimberUi to your mod's `manifest.json` `RequiredMods` list and reference the assembly from your `.csproj`. TimberUi pulls in Bindito and Timberborn's UIElements/CoreUI, so its extension methods become available on the game's own types (`VisualElement`, `Configurator`, `BaseComponent`, …) just by referencing it.
+
+### 2. Register a configurator per context
+
+TimberUi's DI is attribute-driven. To switch it on for your mod, add one `Configurator` per game state (context) that scans your assembly for `[Bind…]` attributes. The simplest way is to subclass the matching `AttributeConfigurator` base and tag it with Timberborn's `[Context]` attribute:
+
+```cs
+[Context("MainMenu")]
+public class MyMainMenuConfig : MainMenuAttributeConfigurator { }
+
+[Context("Game")]
+public class MyGameConfig : GameAttributeConfigurator { }
+```
+
+Each base's `Configure()` calls `this.BindAttributes(Context, GetAssembly())`, scanning **its own assembly** for attributes whose context matches. (Override `GetAssembly()` if your `[Bind…]` types live in a different assembly than the configurator.) The four bases are `BootstrapperAttributeConfigurator`, `MainMenuAttributeConfigurator`, `GameAttributeConfigurator`, and `MapEditorAttributeConfigurator`.
+
+### 3. Declare your services and UI with attributes
+
+```cs
+[BindSingleton]                       // a Game-context singleton
+public class MyService { /* ... */ }
+
+[BindFragment]                        // an entity-panel inspector fragment
+public class MyFragment : BaseEntityPanelFragment<MyComponent> { /* ... */ }
+```
+
+No imperative `Bind` calls required — the configurator from step 2 discovers and binds these. The full attribute set and the imperative helpers (for rebinding game services, multibinding, template modules) are covered in [Dependency Injection](./DependencyInjection.MD).
+
+### 4. Build UI with the fluent DSL
+
+Inside a fragment or dialog, assemble the visual tree with chainable `Add…`/`Set…` extensions:
+
+```cs
+var row = root.AddRow();
+row.AddLabel("Name").SetMarginRight();
+row.AddTextField(onValueChanged: OnNameChanged).SetFlexGrow();
+row.AddButton("Save", onClick: Save, style: GameButtonStyle.Menu);
+```
+
+See [Building UI](./BuildingUi.MD) for the full builder catalog.
+
+## Guides
+
+- [Dependency Injection](./DependencyInjection.MD) — the `[Bind…]` attribute family, context filtering, and the imperative `Configurator` helpers for binding, multibinding, template modules, and rebinding game services.
+- [Building UI](./BuildingUi.MD) — the fluent UiBuilder DSL: rows, labels, buttons, text/number fields, sliders, dropdowns, images, progress bars, rich text, and inline styling.
+- [Entity Panel Fragments](./EntityPanelFragments.MD) — add inspector panels to buildings and characters with `BaseEntityPanelFragment<T>`, choose their position, and control their order.
+- [Dialogs & Prompts](./DialogsAndPrompts.MD) — show alerts, confirmations, and text/number input dialogs with `DialogService` and the `DialogBoxElement` family.
+- [Alerts & Bars](./AlertsAndBars.MD) — register alert-panel fragments, bottom-bar modules, and top-bar buttons.
+- [Optional Services](./OptionalServices.MD) — opt-in services: camera shake, mod audio clips, native file dialogs, sprite operations, achievements, update notifications, and named icons.
+- [Utilities](./Utilities.MD) — WAV loading, serializable collections, localization and persistence helpers, text-to-texture rendering, the entity-select tool, and USS/UXML export.

--- a/Docs/TimberUi/Utilities.MD
+++ b/Docs/TimberUi/Utilities.MD
@@ -229,7 +229,7 @@ byte[] encoded = WavUtility.FromAudioClip(clip, out string? savedPath, saveAsFil
 
 `SelectEntityTool` is an injectable singleton tool that lets a player click on an entity in the game world and returns the result asynchronously. It handles cursor switching, raycasting, rollover highlighting, and re-selecting the original entity when the tool exits — you just `await` the result.
 
-It is registered automatically for the Game context via `[BindSingleton(Contexts = BindAttributeContext.NonMenu)]`. Inject it wherever you need it.
+It is registered automatically in the **Game and Map Editor** contexts via `[BindSingleton(Contexts = BindAttributeContext.NonMenu)]` (`NonMenu` = `Game | MapEditor`). Inject it wherever you need it.
 
 ### Basic usage
 

--- a/Docs/TimberUi/Utilities.MD
+++ b/Docs/TimberUi/Utilities.MD
@@ -1,0 +1,497 @@
+# Utilities
+
+TimberUi ships a grab-bag of small, self-contained utilities that many mods find useful. This page covers localization shortcuts, persistence pair helpers, serializable numeric collections, collection utilities, WAV audio loading, the interactive entity-select tool, text-to-texture rendering, and UXML/USS tree-inspection tools.
+
+---
+
+## Localization helpers
+
+**Source:** [`Extensions/Loc.cs`](../../TimberUi/TimberUi/Extensions/Loc.cs)  
+**Namespace:** `Timberborn.Localization` (methods appear on `string` and `ILoc` — no extra `using` needed)
+
+The `T` family turns a localization key string into its translated value using an injected `ILoc`, mirroring Timberborn's own `ILoc.T(key)` call but written as an extension on the key rather than the service.
+
+```cs
+// Translate a key with no substitution
+string label = "MyMod.SomeKey".T(loc);
+
+// Translate with up to three substitution arguments
+string msg = "MyMod.Greeting".T(loc, playerName);
+
+// Translate with a format-string style (any number of args)
+string fmt = "MyMod.Report".TFormat(loc, count, total);
+```
+
+`ILoc` also gains extension methods for the five most common game strings. These are cached after their first call:
+
+```cs
+string yes    = loc.TYes();     // "Core.Yes"
+string no     = loc.TNo();      // "Core.No"
+string ok     = loc.TOK();      // "Core.OK"
+string cancel = loc.TCancel();  // "Core.Cancel"
+string none   = loc.TNone();    // "Inventory.NothingSelected"
+
+// Convenience boolean → yes/no
+string label = loc.TYesNo(building.IsEnabled);
+```
+
+`Priority` and `PopulationCounterMode` values also get localization extensions:
+
+```cs
+string priorityLabel = Priority.High.T(loc);
+string modeLabel = PopulationCounterMode.Beavers.T(loc);
+```
+
+> The `TYes`/`TNo`/`TOK`/`TCancel`/`TNone` results are cached in static fields on first access. They are suitable for UIs that remain in one language for the lifetime of a play session.
+
+---
+
+## Persistence pair helpers
+
+**Source:** [`Extensions/Persistences.cs`](../../TimberUi/TimberUi/Extensions/Persistences.cs)  
+**Namespace:** `Timberborn.Persistence`
+
+When you need to save a key-value pair into a Timberborn save file, `SetPair`/`GetPair` serialize the pair as a single `|`-delimited string under one `PropertyKey<string>`. Both key and value must implement `IConvertible` (all primitive numeric types, `string`, `bool`, and `enum` qualify).
+
+```cs
+// Saving
+public void Save(IObjectSaver saver)
+{
+    saver.SetPair(_mappingKey, new KeyValuePair<string, int>("iron", 42));
+}
+
+// Loading
+public void Load(IObjectLoader loader)
+{
+    KeyValuePair<string, int> pair = loader.GetPair<string, int>(_mappingKey);
+}
+```
+
+To save or load a whole list of pairs at once, use `SetPairs`/`GetPairs` with a `ListKey<string>`:
+
+```cs
+// Saving a collection
+saver.SetPairs(_allMappingsKey, myDictionary);
+
+// Loading a collection back into a dictionary
+var pairs = loader.GetPairs<string, int>(_allMappingsKey);
+var dict = pairs.ToDictionary(p => p.Key, p => p.Value);
+```
+
+The default separator is `|` (`TimberUIPersistencesExtensions.DefaultSeparator`). You can supply a different `char` as an optional third argument. Keep keys and values free of the separator character — the implementation is a plain split with no escaping. A separator embedded in a key or value corrupts the round-trip, and a malformed entry throws `IndexOutOfRangeException` on load.
+
+---
+
+## Serializable collections
+
+**Source:** [`Helpers/SerializableFloats.cs`](../../TimberUi/TimberUi/Helpers/SerializableFloats.cs), [`Helpers/SerializableInts.cs`](../../TimberUi/TimberUi/Helpers/SerializableInts.cs)  
+**Namespace:** `TimberUi.Helpers`
+
+`SerializableFloats` and `SerializableInts` are `readonly record struct` types that hold four numeric components (X, Y, Z, W) and serialize them as a semicolon-delimited string. They plug directly into Timberborn's `IValueSerializer<T>` system, making it straightforward to persist any Unity vector, color, quaternion, or rect into a save file.
+
+Both types carry broad implicit conversions so you usually never need to construct them explicitly:
+
+| Implicit conversion | `SerializableFloats` | `SerializableInts` |
+|---|:---:|:---:|
+| `Vector2` / `Vector2Int` | Yes | Yes |
+| `Vector3` / `Vector3Int` | Yes | Yes |
+| `Vector4` | Yes | — |
+| `Color` | Yes | — |
+| `Quaternion` | Yes | — |
+| `Rect` / `RectInt` | Yes | Yes |
+| `SerializableInts` → `SerializableFloats` | Yes | — |
+
+### Saving a `Color`
+
+Register the serializer with Timberborn's `IObjectSaver`/`IObjectLoader` pattern:
+
+```cs
+static readonly PropertyKey<SerializableFloats> ColorKey = new("HighlightColor");
+static readonly IValueSerializer<SerializableFloats> Serializer = SerializableFloats.Serializer;
+
+public void Save(IObjectSaver saver)
+{
+    saver.Set(ColorKey, (SerializableFloats)myColor, Serializer);
+}
+
+public void Load(IObjectLoader loader)
+{
+    Color loaded = loader.Get(ColorKey, Serializer); // implicit Color cast
+}
+```
+
+### Saving a `Vector3Int`
+
+```cs
+static readonly PropertyKey<SerializableInts> PositionKey = new("Position");
+static readonly IValueSerializer<SerializableInts> Serializer = SerializableInts.Serializer;
+
+saver.Set(PositionKey, (SerializableInts)myVector3Int, Serializer);
+Vector3Int pos = loader.Get(PositionKey, Serializer); // implicit Vector3Int cast
+```
+
+`Deconstruct` overloads (2-, 3-, and 4-component) let you unpack directly into tuples:
+
+```cs
+var (x, y) = (SerializableFloats)someVector2;
+var (x, y, z) = (SerializableFloats)someVector3;
+```
+
+---
+
+## Collection utilities
+
+**Source:** [`Helpers/ListExtensions.cs`](../../TimberUi/TimberUi/Helpers/ListExtensions.cs), [`Helpers/TimberUiUtils.cs`](../../TimberUi/TimberUi/Helpers/TimberUiUtils.cs)  
+**Namespace:** `TimberUi.Helpers` / `TimberUi`
+
+### `ListExtensions`
+
+Two LINQ-style extensions using C# 13 `extension` block syntax:
+
+```cs
+// Pick a random element from any IReadOnlyList<T>
+// Returns default(T) when the list is empty.
+string? pick = myList.Randomize();
+
+// First-match index (returns -1 if not found)
+int idx = myItems.FindIndex(item => item.Name == "copper");
+```
+
+### `TimberUiUtils` — standard UI colors and miscellany
+
+`TimberUiUtils` (namespace `TimberUi`) provides named `Color` constants that match Timberborn's visual language:
+
+| Constant | Usage |
+|---|---|
+| `SuccessColor` | Green — positive, OK |
+| `NeutralColor` | Light grey — informational |
+| `WarningColor` | Amber — caution |
+| `DangerColor` | Dark red — destructive or error |
+| `TransparentColor` | Fully transparent black |
+
+```cs
+highlight.SetBackgroundColor(TimberUiUtils.WarningColor);
+```
+
+Other utilities on `TimberUiUtils`:
+
+```cs
+// Check whether MoreModLogs is loaded (gates verbose logging)
+if (TimberUiUtils.HasMoreModLogs) { /* ... */ }
+
+// Load a WAV file as an AudioClip (delegates to WavUtility)
+AudioClip clip = TimberUiUtils.LoadAudioClipFrom("path/to/sound.wav", name: "MySound");
+AudioClip clip2 = TimberUiUtils.LoadAudioClipFrom(wavBytes, name: "MySound");
+
+// Get all values of an enum, sorted
+ImmutableArray<Priority> values = TimberUiUtils.GetSortedEnumValues<Priority>();
+```
+
+`LogVerbose` emits a `Debug.Log` only when MoreModLogs is loaded — convenient for high-frequency diagnostics that should stay quiet in production:
+
+```cs
+TimberUiUtils.LogVerbose(() => $"Processed {count} items.");
+```
+
+---
+
+## WAV audio loading
+
+**Source:** [`Helpers/WavUtility.cs`](../../TimberUi/TimberUi/Helpers/WavUtility.cs)  
+**Namespace:** `TimberUi.Helpers`
+
+`WavUtility` is a static utility (ported from [deadlyfingers/UnityWav](https://github.com/deadlyfingers/UnityWav)) that converts uncompressed PCM WAV data to and from Unity `AudioClip` objects. It supports 8-bit, 16-bit, 24-bit, and 32-bit PCM; only uncompressed formats (format code 1 or WaveFormatExtensible 65534) are intended to be used. Note that the format validation is implemented with `Debug.Assert*` calls, which are stripped in release builds — malformed or compressed input is not reliably rejected at runtime. Validate your input beforehand.
+
+The preferred entry point for most mods is `TimberUiUtils.LoadAudioClipFrom`, which delegates here, but you can also call `WavUtility` directly:
+
+```cs
+// Load from a file path
+AudioClip clip = WavUtility.ToAudioClip("path/to/alert.wav");
+
+// Load from raw bytes (e.g. embedded resource)
+AudioClip clip = WavUtility.ToAudioClip(wavBytes, name: "Alert");
+
+// Encode an AudioClip back to 16-bit PCM WAV bytes
+byte[] encoded = WavUtility.FromAudioClip(clip);
+
+// Encode and save to Application.persistentDataPath/recordings/
+byte[] encoded = WavUtility.FromAudioClip(clip, out string? savedPath, saveAsFile: true);
+```
+
+`FromAudioClip` always outputs 16-bit PCM regardless of the original clip's bit depth. Use `saveAsFile: false` when you only need the byte array.
+
+---
+
+## Entity-select tool
+
+**Source:** [`Tools/SelectEntityTool.cs`](../../TimberUi/TimberUi/Tools/SelectEntityTool.cs)  
+**Namespace:** `TimberUi.Tools`
+
+`SelectEntityTool` is an injectable singleton tool that lets a player click on an entity in the game world and returns the result asynchronously. It handles cursor switching, raycasting, rollover highlighting, and re-selecting the original entity when the tool exits — you just `await` the result.
+
+It is registered automatically for the Game context via `[BindSingleton(Contexts = BindAttributeContext.NonMenu)]`. Inject it wherever you need it.
+
+### Basic usage
+
+```cs
+[BindSingleton]
+public class MyService(SelectEntityTool selectTool)
+{
+    public async Task PickTarget()
+    {
+        EntityComponent? entity = await selectTool.SelectAsync();
+
+        if (entity is null)
+        {
+            return; // player cancelled or switched tool
+        }
+
+        // entity is the EntityComponent the player clicked
+    }
+}
+```
+
+### Configuring the selection session
+
+Pass a `SelectEntityToolOptions` to control behavior:
+
+```cs
+// Injected: SelectEntityTool selectTool
+EntityComponent? picked = await selectTool.SelectAsync(
+    new SelectEntityToolOptions(Cursor: "PickObjectCursor"));
+if (picked is null) { return; } // cancelled, or the object had no EntityComponent
+```
+
+All fields of `SelectEntityToolOptions` (`Source`, `Cursor`, `HighlightColor`, `Filter`) are optional. `Filter` receives the `SelectableObject` under the cursor; objects that fail the filter are not highlighted and cannot be selected.
+
+`Source` is a `BaseComponent?` that is re-selected (re-opening its panel) when the tool exits — pass a real `BaseComponent` instance or omit it. Do not pass `this` from a plain service class that is not itself a `BaseComponent`. A `null` result means either the player cancelled or the clicked object had no `EntityComponent` attached.
+
+---
+
+## Text-to-texture rendering
+
+**Source:** [`Services/TextTexture/TextTexture.cs`](../../TimberUi/TimberUi/Services/TextTexture/TextTexture.cs), [`TextTextureRenderer.cs`](../../TimberUi/TimberUi/Services/TextTexture/TextTextureRenderer.cs)  
+**Namespace:** `TimberUi.Services`
+
+The text-texture subsystem rasterizes an arbitrary string into a Unity `Texture2D` using an OS-installed font. This is useful for in-world signage, custom material maps, or any situation where text must live in a texture rather than in UI Toolkit.
+
+The subsystem is a two-class API: `TextTextureRenderer` (an exported bootstrapper singleton) allocates and manages `TextTexture` instances; `TextTexture` is a disposable wrapper around a `Texture2D` that you `Render` to.
+
+### Creating a `TextTexture`
+
+Inject `TextTextureRenderer` and call `Create`:
+
+```cs
+[BindSingleton]
+public class MySignService(TextTextureRenderer textRenderer) : IUnloadableSingleton
+{
+    TextTexture? _sign;
+
+    public void Load()
+    {
+        // 256×64 px, prefer a monospace font at 48pt
+        _sign = textRenderer.Create(256, 64, TextTextureRenderer.MonospaceFonts, fontSize: 48);
+    }
+
+    public void Unload()
+    {
+        _sign?.Dispose();
+        _sign = null;
+    }
+}
+```
+
+`MonospaceFonts` and `DefaultFonts` are static `string[]` arrays listing preferred OS font names in priority order. Unity picks the first available. You can supply your own list.
+
+### Rendering text
+
+Once you have a `TextTexture`, call `Render`. Subsequent calls with the same content and options are no-ops — the result is cached until content or options change.
+
+```cs
+// Render with default options (word-wrap, center alignment, tab size 4)
+_sign.Render("Hello, Timberborn!");
+
+// Render with custom options
+var options = new TextTextureRenderOptions(
+    TabSize: 4,
+    WrapMode: TextTextureRenderWrapMode.Space,
+    HorizontalAlignment: TextTextureRenderAlignment.Start,
+    VerticalAlignment: TextTextureRenderAlignment.Center
+);
+_sign.Render("Line one\nLine two", options);
+
+// Use the texture on a material
+myRenderer.material.mainTexture = _sign.Texture;
+```
+
+`WrapMode` options:
+
+| Value | Behaviour |
+|---|---|
+| `None` | No wrapping — only `\n` breaks lines |
+| `Space` | Word-wrap at spaces (default) |
+| `Anywhere` | Break at any character boundary |
+
+### Measuring text
+
+`MeasureUnbound` returns the pixel size a string would occupy with no wrapping constraints, at the texture's font and size:
+
+```cs
+Vector2Int size = _sign.MeasureUnbound("Hello!");
+```
+
+### Glyph appearance
+
+Glyphs are rendered as a white mask whose alpha channel preserves the source font's anti-aliased coverage — only the source color/hue is discarded. Tint the texture downstream via material color or a UI `Image` tint color.
+
+### Disposal and ref-counting
+
+Each `TextTexture` holds a reference to a shared per-font glyph cache. The cache is freed automatically when every `TextTexture` that uses a given font and size is disposed. Always dispose `TextTexture` instances when they are no longer needed, either explicitly or from `IUnloadableSingleton.Unload`.
+
+---
+
+## Visual-tree debugging
+
+**Source:** [`UnityUiElements/UxmlExporter.cs`](../../TimberUi/TimberUi/UnityUiElements/UxmlExporter.cs), [`UnityUiElements/StyleSheetToUss.cs`](../../TimberUi/TimberUi/UnityUiElements/StyleSheetToUss.cs), [`Extensions/Helpers.cs`](../../TimberUi/TimberUi/Extensions/Helpers.cs)  
+**Namespaces:** `UnityEditor.UIElements.Debugger`, `UnityEditor.StyleSheets`, `UnityEngine.UIElements`
+
+These tools let you dump a live UI tree to UXML text and convert individual `StyleSheet` objects to USS text at runtime — useful for understanding Timberborn's own panel structure when writing matching mod UI.
+
+### Dumping a visual tree
+
+The quickest path is the `PrintVisualTree` / `DescribeVisualTree` extensions that live on any `VisualElement` (via `Helpers.cs`):
+
+```cs
+// Log the UXML of an entire panel to the Unity console
+myPanel.PrintVisualTree();
+
+// Note: the bool overload always includes TemplateContainer contents regardless of the argument;
+// prefer the (templateId, options) overload of UxmlExporter.Dump for explicit control.
+myPanel.PrintVisualTree(printTemplates: true);
+
+// Retrieve the UXML string without logging
+string uxml = myPanel.DescribeVisualTree();
+
+// Pass explicit export options
+string uxml = myPanel.DescribeVisualTree(
+    options: UxmlExporter.ExportOptions.NewLineOnAttributes | UxmlExporter.ExportOptions.AutoNameElements
+);
+```
+
+You can also call `UxmlExporter.Dump` directly when you need more control:
+
+```cs
+string uxml = UxmlExporter.Dump(
+    myElement,
+    templateId: "MyMod.MyPanel",
+    options: UxmlExporter.ExportOptions.PrintTemplate
+);
+```
+
+`ExportOptions` is a `[Flags]` enum:
+
+| Flag | Effect |
+|---|---|
+| `NewLineOnAttributes` | Each XML attribute on its own line |
+| `StyleFields` | Declared but not yet fully implemented |
+| `AutoNameElements` | Emits a synthetic `name` attribute (TypeName + text) for elements that are unnamed or whose name starts with `_` |
+| `PrintTemplate` | Recurse into `TemplateContainer` children |
+
+### Converting a `StyleSheet` to USS text
+
+`StyleSheetToUss` provides granular overloads for converting individual selectors, rules, and value handles back to USS text. Work at the rule or selector level — the whole-`StyleSheet` `ToUssString(StyleSheet, …)` overload and `WriteStyleSheet` unconditionally throw `NotSupportedException`, as do the obsolete `Print`/`Describe`/`PrintStylesheet` extension helpers that route through them. Only the per-rule, per-selector, per-value, and `Color` overloads are functional.
+
+```cs
+var sb = new StringBuilder();
+var exportOptions = new UssExportOptions();
+
+// Emit a single rule
+StyleSheetToUss.ToUssString(styleSheet, exportOptions, someRule, sb);
+string ruleText = sb.ToString();
+
+// Emit a single selector
+string selector = StyleSheetToUss.ToUssSelector(complexSelector);
+
+// Emit a Color value
+string colorText = StyleSheetToUss.ToUssString(Color.red, useColorCode: true);
+```
+
+Use `UssExportOptions` to control formatting:
+
+| Property | Default | Description |
+|---|---|---|
+| `propertyIndent` | `"    "` | Indentation string for each property |
+| `useColorCode` | `false` | Emit colors as hex (`#rrggbbaa`) instead of `rgb()`/`rgba()` |
+| `withComment` | `true` | Include comments from `UssComments` |
+| `exportDefaultValues` | `true` | Include properties whose value is the USS default |
+
+---
+
+## Color conversions
+
+**Source:** [`Extensions/Conversions.cs`](../../TimberUi/TimberUi/Extensions/Conversions.cs)  
+**Namespace:** `UnityEngine` (methods appear on `Color`, `Vector3`, `Vector4`, `Vector3Int` — no extra `using` needed)
+
+A small set of extensions for converting between `Color` and Unity vector types, in two directions.
+
+### Normalized (0–1) conversions
+
+```cs
+Color c = new Color(0.2f, 0.4f, 0.8f, 1f);
+
+Vector3 v3 = c.ToVector3();   // (r, g, b) — alpha dropped
+Vector4 v4 = c.ToVector4();   // (r, g, b, a)
+
+Color fromV3 = v3.ToColor();  // alpha defaults to 1
+Color fromV4 = v4.ToColor();  // all four components
+```
+
+### 0–255 conversions
+
+Note the direction-dependent return types carefully: converting a `Color` to 255-range yields a vector; converting a vector to a `Color` divides by 255.
+
+```cs
+Color c = new Color(0f, 0.502f, 1f);  // roughly (0, 128, 255) in byte terms
+
+Vector3    asFloat = c.ToColor255();         // (0f, 128.0f, 255f)   — float components, returns Vector3
+Vector3Int asInt   = c.ToColor255Int();      // (0, 128, 255)         — rounded to int, returns Vector3Int
+
+Color fromFloat = new Vector3(0f, 128f, 255f).ToColor255();         // divides by 255 → Color
+Color fromInt   = new Vector3Int(0, 128, 255).ToColor255();         // divides by 255 → Color
+```
+
+| Extension | Receiver | Returns | Direction |
+|---|---|---|---|
+| `ToVector3()` | `Color` | `Vector3` (r,g,b) | Color → vector |
+| `ToVector4()` | `Color` | `Vector4` (r,g,b,a) | Color → vector |
+| `ToColor()` | `Vector3` | `Color` | vector → Color |
+| `ToColor()` | `Vector4` | `Color` | vector → Color |
+| `ToColor255()` | `Color` | `Vector3` (×255) | Color → 0–255 float vector |
+| `ToColor255Int()` | `Color` | `Vector3Int` (×255, rounded) | Color → 0–255 int vector |
+| `ToColor255()` | `Vector3` | `Color` (÷255) | 0–255 float vector → Color |
+| `ToColor255()` | `Vector3Int` | `Color` (÷255) | 0–255 int vector → Color |
+
+---
+
+## Key types
+
+| Type | Namespace | Description |
+|---|---|---|
+| `UiBuilderExtensions` (Loc portion) | `Timberborn.Localization` | `string.T(ILoc, …)` and `ILoc.TYes/TNo/TOK/TCancel/TNone` |
+| `TimberUIPersistencesExtensions` | `Timberborn.Persistence` | `IObjectSaver.SetPair/SetPairs`, `IObjectLoader.GetPair/GetPairs` |
+| `SerializableFloats` | `TimberUi.Helpers` | 4-component float record struct with Unity type conversions and `IValueSerializer` |
+| `SerializableInts` | `TimberUi.Helpers` | 4-component int record struct with Unity type conversions and `IValueSerializer` |
+| `ListExtensions` | `TimberUi.Helpers` | `IReadOnlyList<T>.Randomize()`, `IEnumerable<T>.FindIndex(Predicate<T>)` |
+| `TimberUiUtils` | `TimberUi` | UI color constants, `LoadAudioClipFrom`, `GetSortedEnumValues<T>`, `LogVerbose` |
+| `WavUtility` | `TimberUi.Helpers` | PCM WAV ↔ `AudioClip` encode/decode |
+| `SelectEntityTool` | `TimberUi.Tools` | Awaitable entity-pick tool |
+| `SelectEntityToolOptions` | `TimberUi.Tools` | Options for a `SelectEntityTool` session |
+| `TextTextureRenderer` | `TimberUi.Services` | Bootstrapper singleton — allocates `TextTexture` instances |
+| `TextTexture` | `TimberUi.Services` | Per-texture render target; call `Render(content)` and read `Texture` |
+| `TextTextureRenderOptions` | `TimberUi.Services` | Wrap mode, alignment, tab size |
+| `TextTextureRenderWrapMode` | `TimberUi.Services` | `None`, `Space`, `Anywhere` |
+| `TextTextureRenderAlignment` | `TimberUi.Services` | `Start`, `Center`, `End` |
+| `UxmlExporter` | `UnityEditor.UIElements.Debugger` | Dumps a `VisualElement` tree to UXML string |
+| `StyleSheetToUss` | `UnityEditor.StyleSheets` | Converts `StyleSheet` objects to USS text |
+| `UssExportOptions` | `UnityEditor.StyleSheets` | Formatting options for USS export |
+| `TimberUIHelperExtensions` (Conversions portion) | `UnityEngine` | `Color`↔`Vector3/4` and 0–255 conversions |


### PR DESCRIPTION
Adds task-based consumer documentation for **TimberUi** under `Docs/TimberUi/`, following the same convention as the existing `Docs/ModdableTimberborn/` guides, and links the new section from the top-level `Docs/README.MD`.

## Contents (10 guides + index)

- **README** — overview + getting started (register an `AttributeConfigurator`, declare services/UI with `[Bind…]` attributes, build UI with the DSL).
- **Dependency Injection** — the `[Bind…]` attribute family, context filtering, and the imperative `Configurator` helpers (binding, multibinding, template modules, rebinding game services).
- **Decorating Game Prefabs** — attaching components to existing buildings/characters via `[AddTemplateModule2]` and `BindTemplateModule`.
- **Building UI** — the fluent UiBuilder DSL: rows, labels, buttons, fields, sliders, dropdowns, images, progress bars, rich text, styling, and composite widgets (`ToggleGroup`, `RecipeRow`).
- **Entity Panel Fragments** — inspector panels via `BaseEntityPanelFragment<T>`, positions, and ordering.
- **Dialogs & Prompts** — `DialogService`, `DialogBoxElement`, and the `InputDialogBox` family.
- **Alerts & Bars** — alert-panel fragments, bottom-bar modules, top-bar buttons.
- **HUD & Main-Menu Injection** — top-right HUD items (`UILayout.AddTopRight`) and main-menu button injection.
- **Optional Services** — camera shake, mod audio clips, native file dialogs, sprite operations, achievements, update notifications, named icons.
- **Utilities** — WAV loading, serializable collections, localization/persistence helpers, text-to-texture, the entity-select tool, USS/UXML export.
- **Developer Panel Tools** — `IDevModule` dev-panel sections, dumping the live UI tree, and a dev-mode toggle.

All examples are source-verified against the TimberUi library and grounded in the demo project where one exists. Happy to adjust structure, depth, or wording to taste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)