### PR TITLE
Add per-folder README documentation for TimberUi

### DIFF
--- a/TimberUi/TimberUi/CommonProviders/README.md
+++ b/TimberUi/TimberUi/CommonProviders/README.md
@@ -1,0 +1,28 @@
+# CommonProviders
+
+## Purpose
+Reusable Bindito `IProvider<...>` base classes that wrap Timberborn's various UI "module" builders. Timberborn registers entity-panel fragments, alerts, and bottom-bar elements indirectly: you multibind a provider that yields an `EntityPanelModule` / `AlertPanelModule` / `BottomBarModule`, and the game's UI assembles those modules. These classes save the mod author from writing the builder boilerplate by hand — typically they're referenced from the `Configurator.Bind*` extension helpers (e.g. `BindFragment<T>` multibinds `EntityPanelFragmentProvider<T>`, `BindAlertFragment<T>` multibinds `AlertFragmentProvider<T>`) rather than instantiated directly.
+
+## Key types
+- **`EntityPanelFragmentProvider<T>`** (`EntityPanelFragmentProvider.cs`) — generic convenience: wraps a single `T : IEntityPanelFragment` into the non-generic provider at the default position (`Top`).
+- **`EntityPanelFragmentProvider`** (non-generic) — `IProvider<EntityPanelModule>`. Holds an `IEnumerable<EntityPanelRegistration>`. `Get()` builds an `EntityPanelModule.Builder`, then for each registration switches on `Position` and calls the matching `Add*Fragment` builder method (Top/Bottom/Diagnostic/Footer/LeftHeader/Middle/MiddleHeader/Side; LeftHeader passes `Order`). Has convenience ctors taking `IEnumerable<IEntityPanelFragment>` (+ optional `EntityPanelFragmentPosition`).
+- **`EntityPanelRegistration`** — `readonly record struct (IEntityPanelFragment Fragment, EntityPanelFragmentPosition Position, int Order = 0)`.
+- **`EntityPanelFragmentPosition`** — enum of fragment slots in the entity panel. Includes an `[Obsolete] RightHeader`.
+- **`AlertFragmentProvider<T>`** (`AlertFragmentProvider.cs`) — `IProvider<AlertPanelModule>` where `T : IAlertFragmentWithOrder`. `Get()` builds an `AlertPanelModule` adding the single fragment with its `Order`.
+- **`BottomBarModuleProvider<T>`** (`BottomBarModuleProvider.cs`) — `IProvider<BottomBarModule>` where `T : IBottomBarElementsProvider`. `Get()` adds the element to the bottom bar's **right** section and builds.
+- **`SimpleDropdownItemProvider`** (`SimpleDropdownItemProvider.cs`) — `IDropdownProvider` backed by an in-memory `IReadOnlyList<string>` with a mutable selected `value` (defaults to `defaultValue ?? items.First()`). Implements `GetValue`/`SetValue`.
+
+## How it fits together
+A configurator multibinds one of these providers against the game's module collection (e.g. `MultiBind<EntityPanelModule>().ToProvider<EntityPanelFragmentProvider<T>>()`). When Timberborn constructs the relevant panel/bar, it resolves all providers, calls `Get()` on each to obtain a built module, and merges them. The provider receives the actual fragment/element instance via constructor injection (Bindito resolves `T`), so the fragment itself is a normally-bound service. `SimpleDropdownItemProvider` is different: it's the value-backing model handed to a dropdown control, not a module provider.
+
+## Dependencies & patterns
+- **Bindito** — `IProvider<T>` is the provider contract; these are designed to be multibound via `.ToProvider<...>()`.
+- **Timberborn** — `EntityPanelModule(.Builder)`, `AlertPanelModule(.Builder)`, `BottomBarModule(.Builder)`, `IEntityPanelFragment`, `IBottomBarElementsProvider`, `IDropdownProvider`; `IAlertFragmentWithOrder` is TimberUi's own interface (see `CommonUi/IAlertFragmentWithOrder.cs`).
+- **Pattern** — thin builder-wrapping providers + primary-constructor injection. The generic→non-generic delegation in `EntityPanelFragmentProvider` keeps a single `Get()` implementation.
+
+## Usage notes
+- **Fixed section for `BottomBarModuleProvider`:** this provider always targets the **right** section (`AddRightSectionElement`). For left-section placement, implement `IProvider<BottomBarModule>` directly.
+- **Fixed position for the generic `EntityPanelFragmentProvider<T>`:** the single-fragment generic variant always uses `Top`. To place a fragment at a different position, use the non-generic ctor with an explicit `EntityPanelFragmentPosition`.
+- **`[Obsolete] RightHeader`:** `EntityPanelFragmentPosition.RightHeader` is deprecated; use one of the current position values instead.
+- **`Order` on `EntityPanelRegistration`:** the `Order` field is used by the `LeftHeader` position. For other positions, ordering is determined by the multibind registration sequence.
+- **`SimpleDropdownItemProvider` initial value:** when no `defaultValue` is supplied, the selected value is initialized to the first element of `items`. Ensure `items` is non-empty when using this constructor overload.

--- a/TimberUi/TimberUi/CommonUi/README.md
+++ b/TimberUi/TimberUi/CommonUi/README.md
@@ -1,0 +1,65 @@
+# CommonUi
+
+## Purpose
+A catalog of reusable, custom `VisualElement` widgets (and a few helper records/factories) that mods can instantiate directly or — more commonly — obtain through the fluent `UiBuilderExtensions` API in `Extensions/`. These wrap Timberborn's CoreUI controls (`Slider`, `Dropdown`, `DialogBox`, `NineSliceVisualElement`, `TProgressBar`, etc.) with mod-friendly, chainable, strongly-typed surfaces so authors don't hand-assemble panels, dialogs, sliders, and entity-fragment boxes from raw UIElements. If you're building a settings panel, a popup dialog, an entity inspector fragment, or a recipe/icon row, these are the building blocks.
+
+## Key types
+
+### Dialogs
+- **`DialogBoxElement`** — Base modal dialog. Builds the CoreUI box chrome (`options-panel` > `sliced-border`/`box__content-container` `NineSliceVisualElement` > `ScrollView Content`). Fluent `SetTitle`, `AddCloseButton(customAction?)`, `SetDialogSize`/`SetDialogPercentSize`. `Show(...)` wraps content in a real Timberborn `DialogBox` and pushes it onto a `PanelStack`; `ShowAsync(...)` returns a `Task<bool>` (true = confirmed). Exposes `OnUIConfirmed`/`OnUICancelled`/`Close` delegating to the inner `DialogBox`.
+- **`InputDialogBox<TInput,TValueType>`** — `DialogBoxElement` subclass adding a prompt label, a `BaseField<TValueType>` input, and OK/Cancel buttons. `ShowAsync` returns `(bool Confirmed, TValueType? Value)`.
+- **`InputDialogBox<TSelf,TInput,TValueType>`** — CRTP layer re-typing `SetPrompt`/`SetValue`/`AddCloseButton` to return `TSelf` for fluent chaining on the concrete subtypes.
+- **`InputDialogBox`** / **`IntegerInputDialogBox`** / **`FloatInputDialogBox`** — concrete string/int/float dialogs. The non-generic `InputDialogBox` also exposes static factories `CreateString/CreateInteger/CreateFloat(ILoc)`.
+
+### Sliders
+- **`GameSlider<TSlider,TValue>`** — Wraps a Timberborn `BaseSlider<TValue>` in a settings-styled row. Fluent `SetLabel`, `SetHorizontalSlider(SliderValues)`, `AddEndLabel(text | Func<TValue,string>)`, `RegisterChange`, `RegisterAlternativeClickCallback`. `RegisterAlternativeManualValue` opens an `InputDialogBox` when the slider is alt-clicked so the user can type an exact value.
+- **`GameSlider<TSelf,TSlider,TValue>`** — CRTP layer re-typing the fluent methods to `TSelf`.
+- **`GameSlider`** (float) / **`GameSliderInt`** (int) — concrete sliders, each with `RegisterAlternativeManualValue` overloads wiring the appropriate `InputDialogBox.CreateFloat/CreateInteger`.
+- **`SliderValues<TValue>`** — record struct `(Low, High, Default)`.
+- **`GameSliderAlternativeManualValueDI`** — `[BindSingleton(Contexts = All)]` bundle of `InputService`, `ILoc`, `VisualElementInitializer`, `PanelStack` so the alt-value dialog can be wired from one injected dependency.
+
+### Dropdown / toggle / collapsible
+- **`DropdownRow<TValue>`** — Label + Timberborn `Dropdown` row, strongly typed over `TValue`. `SetItems` (with optional unique-name generation), `SetSelectedValue/Index` (+ `WithoutNotifying` variants), `OnValueChanged` event carrying an `IndexedDropdownRowItem<TValue>`.
+- **`DropdownRowProvider<TValue>`** — `IDropdownProvider` backing store mapping `TValue` items to display strings; tracks the selected index and raises `OnSelectedIndexChanged`.
+- **`DropdownRowItem<TValue>`** / **`IndexedDropdownRowItem<TValue>`** — record structs for an item and an item-with-index.
+- **`ToggleGroup<TValue>`** — Radio-button-style mutually-exclusive group over a set of `Toggle`s; enforces exactly one selection, exposes `Value`/`SelectedOption`, `SetValue(WithoutNotify)`, `ClearSelection`, `OnValueChanged`.
+- **`ToggleGroupOption<TValue>`** — record struct pairing a `Toggle` with its `TValue`.
+- **`CollapsiblePanel`** — Header (bold clickable label + plus/minus buttons) over a collapsible `Container`. `SetTitle`, `SetExpand`/`ToggleExpand`/`SetExpandWithoutNotify`, `ExpandChanged` event.
+
+### Icons / content rows
+- **`IconSpan`** — Row (or column via `SetVertical`) of optional prefix label + `Image` + optional postfix label. `SetImage`/`SetImageSize`/`SetContent`/`ClearContent`, image source abstracted via `ImageSource`.
+- **`ImageSource`** — record struct holding exactly one of `Sprite`/`Texture`/`VectorImage`, with implicit conversions both ways; `SetImage(Image)` applies it (throws if empty).
+- **`RecipeRow`** — Assembles a full recipe display (ingredients, fuel, arrow, time, products, science) from a `RecipeSpec`, using `IconSpan`s and `NamedIconProvider` glyphs. Built via the injected **`RecipeRowFactory`** (`[BindSingleton]`).
+- **`ProgressBarWithLabel`** — record struct pairing a `TProgressBar` with its `Label`; `SetProgress(progress, text?)` updates both. Constructed by `AddProgressBarWithLabel` in `Extensions/ProgressBars.cs`.
+
+### Entity panel fragments
+- **`EntityPanelFragmentElement`** — `NineSliceVisualElement` styled as an `entity-sub-panel` with a switchable colored background (`Background` enum property), and a `Visible` toggle (display style). The standard container for entity-inspector fragment content.
+- **`EntityPanelFragmentBackground`** — enum: Green/Blue/PurpleStriped/PalePurple/RedStriped/Frame.
+- **`BaseEntityPanelFragment<T>`** (in `DefaultEntityPanelFragment.cs`) — abstract `IEntityPanelFragment` base. Creates an `EntityPanelFragmentElement`, resolves the target component `T` on `ShowFragment`, hides on `ClearFragment`. Subclasses implement `InitializePanel` and override `UpdateFragment`.
+
+### Alerts / top bar / misc
+- **`ClosableAlertElement`** — Wraps an alert row from `AlertPanelRowFactory.CreateClosable(iconName)`: a main `Button` + a `Close` button, with `Visible`, `AddCloseCallback`, `SetButtonCallback`, `SetButtonAsCloseCallback`, `SetText`. Not a `VisualElement` itself — holds `Root`.
+- **`IAlertFragmentWithOrder`** — `IAlertFragment` plus an `int Order` for sorting alert fragments.
+- **`TopBarButton`** — `NineSliceButton` with a switchable `square-large--green/brown` background via its `Background` property.
+- **`TopBarButtonBackground`** — enum: Green/Brown.
+- **`NineSliceFloatField`** — `[UxmlElement]` `FloatField` that paints a `NineSliceBackground` (CoreUI styled float input usable in UXML and as the input field type for float dialogs).
+
+## How it fits together
+Most of these widgets are not constructed directly by mod authors. The `Extensions/` fluent builders (`AddIconSpan`, `AddArrow`, `AddDropdownRow`, `AddProgressBarWithLabel`, `AddGameLabel`, `AddMinusButton`/`AddPlusButton`, `AddCloseButton`, etc.) are the intended entry points and they `new` these classes (or call `AddChild<T>()`) and immediately apply CSS classes from `UiCssClasses`. For example `CollapsiblePanel` builds itself entirely out of `AddRow`/`AddGameLabel`/`AddMinusButton`/`AddPlusButton`/`AddChild`; `RecipeRow` is built from `AddRow`/`AddIconSpan`/`AddArrow`; `GameSlider` from `AddChild<TSlider>`. So this folder defines the *components* and `Extensions/` defines the *fluent grammar* that produces and styles them.
+
+CoreUI integration points:
+- Dialogs bridge into Timberborn's real `DialogBox` + `PanelStack.PushDialog`, so they participate in the game's modal stack, ESC handling, and confirm/cancel plumbing. `VisualElementInitializer`/`VisualElementLoader._visualElementInitializer` is used to bind/initialize the tree before showing.
+- Sliders/dropdowns/toggles wrap CoreUI's `BaseSlider<T>`, `Dropdown`/`IDropdownProvider`, and `Toggle`, adding strong typing and change events on top.
+- Entity fragments implement Timberborn's `IEntityPanelFragment` lifecycle (`Initialize/Show/Clear/Update`) so they slot into the entity inspector.
+- Styling is driven by the shared `UiCssClasses` string table rather than inline styles, so widgets inherit the game's look (`settings-slider`, `entity-sub-panel`, `options-panel`, `progress-bar`, `square-large--*`, etc.).
+
+The CRTP (`TSelf`) layering on sliders and input dialogs exists purely so fluent calls keep the concrete type and stay chainable without casts.
+
+## Dependencies & patterns
+- **Bindito DI:** `RecipeRowFactory` (`[BindSingleton]`) and `GameSliderAlternativeManualValueDI` (`[BindSingleton(Contexts = All)]`) are container-registered; the rest are plain constructibles.
+- **Timberborn CoreUI:** `NineSliceVisualElement`/`NineSliceButton`/`NineSliceBackground`, `DialogBox`/`PanelStack`, `Dropdown`/`IDropdownProvider`/`DropdownItemsSetter`, `BaseSlider<T>`/`Slider`/`SliderInt`, `TProgressBar`, `AlertPanelRowFactory`, `IEntityPanelFragment`/`IAlertFragment`, `NamedIconProvider`, `IGoodService`, `RecipeSpec`, `InputService`, `ILoc`, `VisualElementInitializer`/`VisualElementLoader`.
+- **Unity UIElements:** subclasses of `VisualElement`, `[UxmlElement]` + generated `UxmlSerializedData` (NineSliceFloatField), `generateVisualContent`/`CustomStyleResolvedEvent` for nine-slice painting, `RegisterValueChangedCallback`, `ChangeEvent<T>`.
+- **Patterns:** fluent/chainable builders returning `this`/`TSelf`; CRTP for typed fluent chains; `record struct` value bundles (`SliderValues`, `ImageSource`, `ToggleGroupOption`, `DropdownRowItem`, `ProgressBarWithLabel`); `WithoutNotify` paired setters; backing-field property setters that swap CSS classes (`Background`).
+
+## Usage notes
+- **`ClosableAlertElement`** is not a `VisualElement` — it exposes a `Root` property that holds the actual element. Add `.Root` to a parent container rather than the `ClosableAlertElement` instance itself.

--- a/TimberUi/TimberUi/DIAttributes/README.md
+++ b/TimberUi/TimberUi/DIAttributes/README.md
@@ -1,0 +1,39 @@
+# DIAttributes
+
+## Purpose
+This folder is the engine of TimberUi's attribute-driven dependency injection. It defines the `[Bind]` attribute family that a mod author sticks on classes, and the `AttributeBinder` static class that scans an assembly and translates those attributes into Bindito container bindings. A mod author cares because this is what lets them write `[BindSingleton]` / `[MultiBind(typeof(IFoo))]` / `[BindFragment]` on a class and have it registered automatically per game state, instead of editing a `Configurator` by hand.
+
+## Key types
+- **`BindAttribute`** (`BindAttribute.cs`) — the base registration attribute (`AttributeTargets.Class`, `AllowMultiple`, not inherited). Properties: `Contexts` (default `Game`), `Scope?` (null = use configurator default), `As` (the service type to expose), `AlsoBindSelf`, `Exported`, `MultiBind`. Multiple `[Bind]`s on one class register it several ways.
+- **`BindAttributeContext`** (`BindAttribute.cs`) — `[Flags]` enum (`MainMenu=1, Game=2, MapEditor=4, Bootstrapper=8`, `All=MainMenu|Game|MapEditor`, `NonMenu=Game|MapEditor`). The filter axis.
+- **`BindSingletonAttribute` / `BindTransientAttribute`** (`BindHelpers.cs`) — `BindAttribute` subclasses that preset `Scope` to `Scope.Singleton` / `Scope.Transient`.
+- **`BindMenuSingletonAttribute`** (`BindHelpers.cs`) — `BindSingleton` preset to `Contexts = MainMenu`.
+- **`MultiBindAttribute`** (`BindHelpers.cs`) — ctor takes the `As` type and sets `MultiBind = true` (registers the class into a multibind collection of that service type).
+- **`BindFragmentAttribute`** (`BindHelpers.cs`) — marker (no data) meaning "this `IEntityPanelFragment` should be registered as an entity-panel fragment."
+- **`AddTemplateModuleAttribute`** (`AddTemplateModuleAttribute.cs`) — `[Obsolete]`, superseded by v2. Holds a `Subject` type and `AlsoBindTransient` (default true). Registers `this` class as a template-module decorator of `Subject`.
+- **`AddTemplateModule2Attribute`** — the current version: adds `Contexts` (default `Game`) so decorators can be context-filtered. Holds `Subject`, `AlsoBindTransient`.
+- **`AttributeBinder`** (`AttributeBinder.cs`) — static driver. `BindAttributes(assembly, configurator, defaultScope, context)` is the single entry point called by `Configurator.BindAttributes(...)`.
+
+## How it fits together
+`AttributeConfigurator.Configure()` → `Configurator.BindAttributes(context, assembly)` (extension in `Extensions/Configurators.cs`) → `AttributeBinder.BindAttributes(assembly, configurator, defaultScope, context)`.
+
+Inside `AttributeBinder.BindAttributes`:
+1. Computes `isNonMenu = (context & NonMenu) > 0` and `isGame = (context & Game) > 0`.
+2. Loops over `assembly.GetTypes()`. For each type:
+   - **`BindType`** reads every `[Bind]` on the type; skips any whose `Contexts` don't intersect the active `context`. For each surviving attribute it resolves `scope = attr.Scope ?? defaultScope` and binds:
+     - **MultiBind path** — requires `As`; if `AlsoBindSelf`, binds the concrete type at scope and multibinds `As→type` with `toExisting:true` (the multibind reuses the separately self-bound singleton rather than creating a second instance), else multibinds directly. Honors `Exported`.
+     - **Single path** — if `As` is null, `Bind(type).AsScope(scope)` (+ optional `AsExported`); else `BindExported(As, type, scope, AlsoBindSelf, Exported)`.
+   - **`BindEntityFragment`** — only invoked when `isNonMenu`. If the type has `[BindFragment]`, asserts it implements `IEntityPanelFragment` (throws otherwise) and registers it via `BindOrderedFragment` (if it also implements `IEntityFragmentOrder`) or `BindFragment`.
+   - **Template modules** — only when `isGame` for the v1 `[AddTemplateModule]`; the v2 `[AddTemplateModule2]` is processed whenever `isNonMenu` and filtered by its own `Contexts`. Each collects a `(Subject, type)` decorator pair and, if `AlsoBindTransient`, binds the decorator type as transient.
+3. After the loop, if any decorators were collected, `BindTemplateModule` registers them all through one `configurator.BindTemplateModule(h => ... h.AddDecorator(sub, dec, false) ...)` call.
+
+## Dependencies & patterns
+- **Bindito** — `Configurator`, `Scope` (`Bindito.Core.Internal.Scope`), `IExportAssignee`, `MultiBind`, `Bind(...).AsScope(...)`, `BindTemplateModule`. The `BindExported` / `Bind(Type,...)` reflection-based helpers live in `Extensions/Configurators.cs`.
+- **Timberborn** — `IEntityPanelFragment`, `IEntityFragmentOrder`, `TemplateModule` decorator system; `BindFragment`/`BindOrderedFragment` extensions (in `Extensions/`).
+- **Pattern** — attribute discovery via reflection (`assembly.GetTypes()` + `GetCustomAttributes<T>()`); context flags as a bitmask filter.
+- **Fail-loud** — invalid attribute combinations throw `InvalidOperationException` (e.g. `MultiBind`/`AlsoBindSelf` without `As`, `[BindFragment]` on a non-fragment). Misuse surfaces at configure time.
+
+## Usage notes
+- **Template modules and fragments require a `NonMenu` context.** A configurator running only in `MainMenu` will not process `[BindFragment]` or `[AddTemplateModule*]` registrations, as those paths are gated on `isNonMenu`. Use `[AddTemplateModule2]` (rather than the obsolete v1) to take advantage of context filtering.
+- **`[BindFragment]` is gated by `isNonMenu`, not by the attribute's own `Contexts`.** Fragment registration applies in any non-menu context regardless of any `Contexts` value on a co-located `[Bind]` attribute.
+- **`AllowMultiple = true` on `BindAttribute`** lets a type be registered several different ways; each attribute is filtered independently by `Contexts`, so one class can be e.g. a `Game` singleton and a separate `MainMenu` binding.

--- a/TimberUi/TimberUi/Extensions/README.md
+++ b/TimberUi/TimberUi/Extensions/README.md
@@ -1,0 +1,82 @@
+# Extensions
+
+## Purpose
+
+This folder is the consumer-facing heart of TimberUi: a large set of `static` extension-method classes that form a fluent **UiBuilder DSL** for assembling Timberborn `VisualElement` trees, plus a set of **configurator/binding helpers** that wrap Bindito DI ceremony into readable one-liners. A mod author building any custom panel, fragment, dialog, or settings UI lives almost entirely in these methods: `parent.AddRow().AddLabel(...).AddButton(...)` chains for layout, and `configurator.BindFragment<T>()` / `BindSingleton<T>()` / `BindTemplateModule(...)` for wiring.
+
+Two distinct concerns share the folder (and mostly share the same `UiBuilderExtensions` type via `partial`):
+1. **UI construction** — `Add*`, `Set*`, `Q*` element builders (the bulk of files).
+2. **DI / configurator wiring** — `Configurators.cs`, `ConfiguratorHelpers.cs`, `OptionalServices.cs`.
+
+Because everything is extension methods on Timberborn/Unity types and is declared in *their* namespaces (`UnityEngine.UIElements`, `Bindito.Core`, `Timberborn.*`), the API surface appears "native" — a mod author gets these methods just by referencing the assembly, with no `using TimberUi` needed.
+
+## Key types
+
+The vast majority of methods hang off one `partial` class **`UiBuilderExtensions`**, deliberately declared in several files across namespaces to match the receiver types. Grouped by file:
+
+### UI element builders (namespace `UnityEngine.UIElements`)
+- **`Childrens.cs`** — the primitives everything else builds on: `AddChild<T>` / `AddChild(Type)` (Activator-creates a `VisualElement`, parents it, applies name + classes), `AddChild<T>(Func<T> factory)`, `AddRow`, `AddHorizontalContainer`, `InsertSelfBefore/After/AsSibling`, `AddLabel` / `AddLabelHeader` / `AddGameLabel`, `AddScrollView` / `AddGameScrollView` / `AddListView`, `AddFragment` (EntityPanelFragmentElement), `AddToggle`, `AddCollapsiblePanel`, plus CSS-class resolvers `GetClasses(GameLabelStyle...)` / `GetGameLabelClasses` / `GetClasses(ToggleStyle)`.
+- **`Buttons.cs`** — `AddButton` (two overloads: `Action` and `EventCallback<ClickEvent>`), style-specific shortcuts `AddMenuButton` / `AddGameButton` / `AddGameButtonPadded` / `AddEntityFragmentButton` / `AddStretchedEntityFragmentButton`, `AddCloseButton`, `AddSquareButton` / `AddPlusButton` / `AddMinusButton`, `AddAction<T>` (register click on any `Button`), `AddClosableAlert`, and the CSS resolver `GetClasses(GameButtonStyle, size, stretched)`. Defines `enum EntityFragmentButtonColor { Green, Red }`.
+- **`TextFields.cs`** — generic `AddValueField<T,TValueType>` plus `AddTextField` / `AddIntField` / `AddFloatField` (the `NineSlice*Field` variants), each wiring an optional `Action<TValue>` change callback.
+- **`Dropdowns.cs`** — `AddDropdown` / `AddMenuDropdown`, `AddChangeHandler`, `SetItems` (via `SimpleDropdownItemProvider`), `SetSelectedItem` (by string or index — index overload range-checks and throws), `GetSelectedValue` / `GetSelectedIndex`.
+- **`DropdownRowExtensions.cs`** — separate class `DropdownRowExtensions`: three `AddDropdownRow<TValue>` overloads building `DropdownRow<TValue>` with label, change handler, and item-setter wiring.
+- **`Sliders.cs`** — `AddSlider` (float) / `AddSliderInt` / `AddMinMaxSlider`, plus a `MinMaxSlider` extension block (`SetLabel`, `SetValue`, `SetValueWithoutNotify`, `RegisterChangeCallback`). Defines `readonly record struct MinMaxSliderValues(Value, Min, Max)`.
+- **`ProgressBars.cs`** — `AddProgressBar` / `AddProgressBarWithLabel` / `AddProgressLabel`, `SetColor` (add/remove a color modifier class on both the host and its inner `"ProgressBar"` child), `SetProgress` (progress + optional label text + old/new color swap). Defines `enum ProgressBarColor { Green, Teal, Red, Blue }`.
+- **`Images.cs`** — `IconSpan` content helpers (`SetGood`, `SetScience`, `SetTime`), `AddIconSpan` (several overloads), `AddArrow`, `AddImage` (by class, sprite, texture, asset path via `IAssetLoader`, or `NamedIconProvider` icon name), `AddInventoryInputImage` / `AddInventoryOutputImage`. Exposes `InventoryInputClasses` / `InventoryOutputClasses` immutable arrays.
+- **`Properties.cs`** — pure inline-style fluent setters: `AddClass` / `AddClasses`, `SetMargin*` / `SetPadding*`, `SetWidth/Height/Size` (+ percent, max, min, min-max variants), `SetAsRow`, `SetWrap`, `SetFlexGrow` / `SetFlexShrink`, `SetDisplay`, `AlignItems`, `JustifyContent`, `SetBorder`, `AddLabelClasses`. This is the styling vocabulary of the DSL.
+- **`Helpers.cs`** — `VisualElement` lifecycle/debug helpers: `Initialize(VisualElementLoader/Initializer)` (required to make game widgets functional — see Usage notes), `SetName`, `PrintVisualTree` / `DescribeVisualTree` (UXML dump via `UxmlExporter`), and obsolete stylesheet print/describe helpers.
+- **`Deconstructions.cs`** — `Deconstruct` for `Vector2/2Int/3/3Int` (enables tuple unpacking).
+- **`Texts.cs`** — rich-text string decorators returning Unity TMP markup strings: `Bold` / `Italic` / `Size` / `Strikethrough` / `Highlight` / `Color`. Defines `enum TimberbornTextColor { Green, Red, Yellow }` (with obsolete `Solid` alias for `Yellow`).
+
+### Localization & data (Timberborn namespaces)
+- **`Loc.cs`** (`Timberborn.Localization`) — `string.T(ILoc)` shorthands (0–3 args + `TFormat`), cached common strings `TYes/TNo/TOK/TCancel/TNone` (plus `TYesNo`, which composes `TYes`/`TNo`), and `Priority` / `PopulationCounterMode` localization.
+- **`BaseComponents.cs`** (`Timberborn.BaseComponentSystem`) — `CommonTimberUiExtensions` on `BaseComponent`: `GetTemplateName`, runtime-typed `GetComponent(Type)` (caches the closed generic `MethodInfo`), `GetName` / `GetLabeledName`.
+- **`Specs.cs`** (`Timberborn.BlueprintSystem`) — `CommonTimberUiExtensions` on `ComponentSpec`: `GetTemplateName`, `GetName(ILoc)`.
+- **`PopulationDataExtensions.cs`** (`Timberborn.Population`) — `PopulationCounterMode.UseCountParameters()` and `PopulationData.GetData` — two overloads: `GetData(mode)` (both count flags hard-coded `true`) and `GetData(mode, countBeavers, countBots)` (both flags required) — a big mode→value switch across population/workplace/contamination data.
+- **`Persistences.cs`** (`Timberborn.Persistence`) — `IObjectLoader.GetPair/GetPairs` and `IObjectSaver.SetPair/SetPairs`: serialize `KeyValuePair<TKey,TValue>` (both `IConvertible`) into a single separator-delimited string (default `'|'`).
+- **`Conversions.cs`** (`UnityEngine`) — `Color`↔`Vector3/4` and 0–255 color conversions (`ToColor255`, `ToColor255Int`, etc.).
+- **`Properties.cs` / `Queries.cs`** — `Queries.cs` exposes `MainMenuPanel.GetMainMenuPanel()` / `GetExitGameButton()` (mod-menu injection points).
+- **`Dialog.cs`** (`Timberborn.CoreUI`) — `DialogBoxShower.ShowAsync(...)`: wraps the callback-based `DialogBoxShower` into an `async Task<bool?>` (true=confirm, false=cancel, null=info) via a `TaskCompletionSource`. The message is a required parameter (localization optional, defaulting to localized); up to 3 button labels are optional.
+
+### DI / configurator wiring (namespace `Bindito.Core`)
+- **`Configurators.cs`** — the core binding helpers (see next section).
+- **`ConfiguratorHelpers.cs`** — fluent entry points to the stateful helper objects: `BindTemplateModule()` (returns a `TemplateModuleHelper`, you must call `.Bind()`) and the `Func`-taking overload that binds for you; `MassRebind()` / `MassRebind(Action<MassRebindingHelper>)`.
+- **`OptionalServices.cs`** — opt-in service bindings safe to call from multiple mods (idempotent via `TryBind`/`IsBound`): `TryBindingCameraShake`, `TryBindingModdableAudioClip` (mod WAV loading; bootstrapper context), `TryBindingAudioClipManagement`, `TryBindingSystemFileDialogService`, `TryBindingSpriteOperations` (MainMenu context only), `BindAchievement<T>`. Contains one obsolete alias (`TryAddingCameraShake`).
+
+## How it fits together
+
+**The UiBuilder pattern.** Almost every builder follows the same contract: it is an extension on `VisualElement` (the parent), it creates a child via `AddChild`, applies a name + a computed list of CSS classes, optionally wires a callback or sets text/value, and **returns the created element** (or, for `Set*`/`AddClass` mutators, returns the same element). That uniform "return the element" convention is what makes the fluent chaining work:
+
+```
+var row = panel.AddRow();
+row.AddLabel("Name").SetMarginRight();
+row.AddTextField(changeCallback: OnNameChanged).SetFlexGrow();
+row.AddButton("OK", onClick: Save, style: GameButtonStyle.Menu);
+```
+
+Styling is layered on via the `Properties.cs` `Set*` mutators (inline `style.*`) and `AddClass/AddClasses` (USS classes from `UiCssClasses`). Enums (`GameButtonStyle`, `GameLabelStyle`, `ProgressBarColor`, etc.) are translated to class strings by the various `GetClasses(...)` resolvers, centralizing the "which USS class" knowledge.
+
+`AddChild` is the universal root: typed `AddChild<T>()` uses `new()`, the `Type` overload uses `Activator.CreateInstance`, and a `Func<T>` overload lets callers construct widgets that need constructor args (e.g. `DropdownRow`). Game-specific widgets returned by these builders frequently must be `Initialize(...)`d (Helpers.cs) before they behave correctly — the builders generally do not call Initialize for you (dropdowns/sliders do it conditionally when both a `VisualElementInitializer` and item-setter are supplied).
+
+**The configurator/binding pattern.** A mod's `Configurator.Configure(IContainerDefinition)` normally writes verbose Bindito chains. `Configurators.cs` collapses these into fluent, chainable `Configurator`-returning helpers:
+
+- **Fragments (entity panels).** `BindFragment<T>()` registers an `IEntityPanelFragment` by wrapping it in `EntityPanelFragmentProvider<T>` and binding it (plus the fragment itself as singleton). `BindFragments<T>()` (on a fragment *provider*) reflects the provider's single parameterized public constructor and auto-singleton-binds every `IEntityPanelFragment` constructor parameter, then multibinds the provider into `EntityPanelModule`. `BindFragmentOrder<T>` / `BindOrderedFragment<T>` add `IEntityFragmentOrder`. `BindAlertFragment<T>` does the alert-panel equivalent. Type-object overloads (`BindFragment(Type)`, `BindOrderedFragment(Type)`) validate the interface and dispatch through cached generic `MethodInfo`s resolved in the static constructor.
+- **General bindings.** `BindSingleton<T>` / `BindSingleton<T,TImpl>` / `BindTransient<T>`, plus runtime-`Type` variants (`Bind(Type)`, `Bind(src,dst,scope,...)`, `BindExported(...)`, `MultiBind(Type,Type)`) that use reflection to invoke the generic Bindito `Bind`/`MultiBind`. `MultiBindSingleton` / `MultiBindAndBindSingleton` cover the multibind+singleton combos. `AsScope(Scope)` maps the `Scope` enum to `AsTransient`/`AsSingleton`.
+- **Removal & queries.** `RemoveBinding` / `MassRemoveBindings` / `RemoveMultibinding(s)` remove entries from the binding registry — used for rebinding/overriding game services. `IsBound` / `TryGetBound` / `IsMultiBound` / `TryBind` / `TryMultiBind` are idempotent guards that make "call from multiple mods" safe (used throughout `OptionalServices.cs`).
+- **Helpers as objects.** For bulk operations, `ConfiguratorHelpers.cs` hands out stateful helper objects (`TemplateModuleHelper`, `MassRebindingHelper`) defined elsewhere in the library; the `Func`/`Action` overloads run-and-`Bind` for you, the bare overloads require an explicit `.Bind()`.
+
+A typical configurator reads top-to-bottom as a fluent script: `configurator.BindSingleton<MyService>().BindFragment<MyFragment>().BindTemplateModule(t => t.Add(...))`.
+
+## Dependencies & patterns
+
+- **Timberborn UIElements / CoreUI:** `NineSliceButton`, `NineSlice*Field`, `Dropdown` / `DropdownRow`, `GameSlider(Int)`, `MinMaxSlider`, `TProgressBar` / `ProgressBarWithLabel`, `IconSpan`, `EntityPanelFragmentElement`, `CollapsiblePanel`, `ClosableAlertElement`, `DialogBoxShower`, `MainMenuPanel`, `VisualElementInitializer` / `VisualElementLoader`, `UxmlExporter`, `UiCssClasses` (the central USS-class constant table).
+- **Bindito.Core:** binding and multibinding infrastructure accessed via reflection to support the runtime-`Type` overloads and the removal/rebinding helpers.
+- **C# 13 `extension` blocks.** Many files use the new `extension(receiver)` / `extension<T>(receiver)` member syntax rather than classic `this`-parameter methods. Both styles coexist (Buttons/Childrens/Properties use classic `this`; Loc/Images/Sliders/Persistences/BaseComponents use `extension` blocks).
+- **Reflection caching:** `getComponentCache` (BaseComponents), the static-constructor-resolved `BindFragmentMethod` / `BindOrderedFragmentMethod` (Configurators) and `GetComponentMethod`. The static constructor throws `InvalidOperationException` if those method lookups fail — a loud, fail-fast initialization.
+- **Fail-loud philosophy:** unknown enum values throw `NotImplementedException`, missing names throw, range checks throw.
+
+## Usage notes
+
+- **Extension methods appear without `using TimberUi`.** Because the extension classes are declared in game and Unity namespaces (`UnityEngine.UIElements`, `Bindito.Core`, `Timberborn.*`), they are in scope whenever those namespaces are already imported — no additional `using` directive is required.
+- **Many game widgets must be initialized before they work.** Timberborn widgets such as sliders, dropdowns, and text fields require `VisualElementInitializer.InitializeVisualElement` to function correctly. Call `Initialize(...)` (from `Helpers.cs`) after adding a widget if you are not passing an initializer directly to the builder method. Slider and dropdown builders call `Initialize` automatically when you supply both an initializer and an item-setter; most other builders leave this to the caller.
+- **`BindFragments<T>()` requires exactly one parameterized public constructor on the provider.** A provider with only a parameterless constructor, or with two or more parameterized constructors, will throw `InvalidOperationException` at bind time.

--- a/TimberUi/TimberUi/Helpers/README.md
+++ b/TimberUi/TimberUi/Helpers/README.md
@@ -1,0 +1,28 @@
+# Helpers
+
+## Purpose
+General-purpose utility code for the TimberUi library: dependency-injection / configurator convenience wrappers, small LINQ-style collection extensions, serializable 4-component numeric structs (with broad implicit conversions to Unity vector/color/rect types and Timberborn `IValueSerializer` support), and audio (WAV PCM encode/decode) utilities. This folder is a grab-bag — the pieces are unrelated to each other and are consumed across the rest of the library.
+
+Note: `TimberUiUtils.cs` physically lives in this folder but declares `namespace TimberUi` (not `TimberUi.Helpers`); everything else here is in `TimberUi.Helpers`.
+
+## Key types
+- **`TemplateModuleHelper`** (`ConfiguratorHelpers.cs`) — fluent builder around Timberborn's `TemplateModule.Builder`. `AddDecorator<TSubject,TDecorator>()` registers a decorator on the builder and (by default) also binds the decorator as transient in the `Configurator`. A non-generic `AddDecorator(Type, Type)` overload reflects into `TemplateModule.Builder.AddDecorator` via a cached `MethodInfo`. `Bind()` multi-binds the built `TemplateModule` as a singleton provider.
+- **`MassRebindingHelper`** (`ConfiguratorHelpers.cs`) — fluent helper to bulk-replace/remove DI bindings. `Replace<TRemove,TReplace>()` (with `TReplace : TRemove`) and `Remove<T>()` accumulate intent; `Bind()` first calls `configurator.MassRemoveBindings(...)` on all keys, then re-adds the replacements via `BindSingleton`. Relies on extension methods defined elsewhere in TimberUi (`MassRemoveBindings`, `BindSingleton(src,dst,bool)`).
+- **`ListExtensions`** (`ListExtensions.cs`) — uses the new C# `extension` member syntax. `IReadOnlyList<T>.Randomize()` returns a random element (or `default` when empty) using `UnityEngine.Random`. `IEnumerable<T>.FindIndex(Predicate<T>)` returns the index of the first match or -1.
+- **`SerializableFloats`** (`SerializableFloats.cs`) — `readonly record struct (float X,Y,Z,W)` with a semicolon-delimited `Serialize()`/`Deserialize()`, multiple `Deconstruct` arities, and a large set of implicit conversions to/from `Vector2/3/4`, `Color`, `Quaternion`, `Rect` (plus one-way conversions from the `Int`/`Vector*Int`/`RectInt`/`SerializableInts` types). Exposes a static `Serializer` (`IValueSerializer<SerializableFloats>`) for Timberborn save data.
+- **`SerializableInts`** (`SerializableInts.cs`) — integer analogue of the above; fewer conversions (`Vector2Int/Vector3Int/RectInt`), same serialize format and nested `SerializableIntsSerializer`.
+- **`TimberUiUtils`** (`TimberUiUtils.cs`) — static grab-bag: a `FrozenSet<string>` of loaded assembly names (computed in the static ctor), `HasMoreModLogs` flag, the Timberborn `SteamId` constant, standard UI `Color`s (Success/Neutral/Warning/Danger/Transparent), `LogVerbose`/`LogDev` logging, `KillProcess`/`Restart` (process control), `LoadAudioClipFrom` (delegates to `WavUtility`), and `GetSortedEnumValues<T>()`.
+- **`WavUtility`** (`WavUtility.cs`) — third-party (deadlyfingers/UnityWav) static class. `ToAudioClip(...)` decodes 8/16/24/32-bit PCM WAV bytes into a Unity `AudioClip`; `FromAudioClip(...)` encodes an `AudioClip` back to 16-bit PCM WAV bytes (optionally writing a timestamped file under `Application.persistentDataPath/recordings`).
+
+## How it fits together
+`TimberUiUtils.LoadAudioClipFrom` is the public entry point that forwards to `WavUtility.ToAudioClip`; mods that need to load custom sounds go through there. The `SerializableFloats`/`SerializableInts` structs are the library's interchange type between Unity geometry/color types and Timberborn's string-based save serialization — their static `Serializer` instances plug into Timberborn's `IValueSerializer<T>` system. The two configurator helpers wrap Timberborn's DI (`Configurator`, `TemplateModule`) for mods doing decoration or wholesale binding replacement. `ListExtensions` and the color constants are leaf utilities consumed ad hoc.
+
+## Dependencies & patterns
+- Heavy reliance on Timberborn types not in this folder: `Configurator`, `TemplateModule(.Builder)`, `IValueSerializer<T>`, `IValueLoader`/`IValueSaver`, `Obsoletable<T>`, and the assumed-existing `Configurator` extension methods (`MultiBind`, `BindTransient`, `MassRemoveBindings`, `BindSingleton`).
+- UnityEngine types (`Vector*`, `Color`, `Quaternion`, `Rect`, `AudioClip`, `Random`, `Debug`, `Application`) resolved via global usings (no explicit `using` lines in most files).
+- Patterns: fluent builders returning `this`; record structs with implicit conversions; cached reflection `MethodInfo`; static-ctor-computed readonly caches.
+
+## Notes
+- **`TimberUiUtils.LogDev` is `[Obsolete]`** — it is intentionally marked obsolete as a debugging aid ("Remember to remove this log after debugging"), so any call site raises a compile-time warning by design.
+- **`Randomize()` returns `default` for empty lists** (i.e. `null` for reference types) rather than throwing. Callers should null-check the result.
+- **`WavUtility`** is third-party code (deadlyfingers/UnityWav). `FromAudioClip` encodes to 16-bit PCM regardless of source bit depth. WAV header parsing assumes a well-formed canonical header layout.

--- a/TimberUi/TimberUi/README.md
+++ b/TimberUi/TimberUi/README.md
@@ -1,0 +1,45 @@
+# TimberUi
+
+## Purpose
+TimberUi is a Timberborn modding library that layers an **attribute-driven dependency-injection and UI-building toolkit** on top of Bindito (Timberborn's DI container) and Unity UIElements. Instead of hand-writing a `Configurator` that calls `Bind<T>().AsSingleton()` for every service, a mod author decorates classes with `[Bind]`, `[BindSingleton]`, `[MultiBind]`, `[BindFragment]`, `[AddTemplateModule2]`, etc., and a single per-context `AttributeConfigurator` scans the assembly and wires everything automatically. On top of the DI layer sits a large set of UI builder extensions and ready-made UIElements controls (dialogs, sliders, dropdowns, entity-panel fragments, bottom-bar buttons, alerts) plus CSS-class and style-enum constants that mirror Timberborn's own USS.
+
+A mod author cares because TimberUi removes most of the Bindito boilerplate, exposes the same registration surface Timberborn uses internally (entity-panel fragments, alerts, bottom-bar modules, template-module decorators), and gives a fluent UI-construction API that targets the game's existing visual style.
+
+## Key types
+- **`AttributeConfigurator`** (`AttributeConfigurator.cs`) — abstract `Bindito.Configurator` base. Its `Configure()` calls `this.BindAttributes(Context, GetAssembly())`, scanning the subclass's own assembly. `Context` (abstract) selects which `BindAttributeContext` is active; `GetAssembly()` defaults to `GetType().Assembly` (override to scan a different assembly).
+- **`MainMenuAttributeConfigurator` / `GameAttributeConfigurator` / `MapEditorAttributeConfigurator` / `BootstrapperAttributeConfigurator`** — the four concrete bases, one per `BindAttributeContext` value. A mod subclasses the one(s) it needs.
+- **`MBootstrapperConfig` / `MMenuConfig` / `MGameConfig` / `MMapConfig`** (`MConfigs.cs`) — TimberUi's own four ready-to-register configurators (trivial subclasses of the four bases). Each carries Timberborn's `[Context(nameof(...))]` attribute so the game's mod loader registers it into the matching DI scope. These are what actually pull TimberUi's library services into each game state.
+- **`BindAttributeContext`** (`DIAttributes/BindAttribute.cs`) — `[Flags]` enum: `MainMenu=1, Game=2, MapEditor=4, Bootstrapper=8`, plus combinations `All = MainMenu|Game|MapEditor` and `NonMenu = Game|MapEditor`. The axis along which every `[Bind]` / template-module attribute is filtered.
+- **`UiCssClasses`** (`UiCssClasses.cs`) — `static partial` bag of string constants and `ImmutableArray<string>` bundles naming Timberborn's USS classes (button variants, fragment backgrounds, label/text styles, slider/toggle/scrollview classes, color names). Used by the UI builder extensions so generated controls match the game skin.
+- **`UiEnums`** (`UiEnums.cs`, namespace `UiBuilder`) — style/size/color enums (`GameLabelStyle`, `GameLabelSize`, `GameLabelColor`, `GameButtonStyle`, `GameButtonSize`, `ToggleStyle`) consumed by the builder extensions to pick a CSS-class set.
+
+## How it fits together
+1. Timberborn's mod loader instantiates the `[Context(...)]`-decorated configurators (`MGameConfig`, etc.) into the corresponding DI scope.
+2. Each configurator's `Configure()` runs `BindAttributes(Context, assembly)`, which delegates to `AttributeBinder.BindAttributes` (see `DIAttributes/`).
+3. `AttributeBinder` enumerates every type in the assembly and, for each, reads its `[Bind]`-family attributes, filtering by whether the attribute's `Contexts` flags intersect the active context. Matching types are bound into the container (singleton/transient/multibind/exported), entity-panel fragments are registered, and `[AddTemplateModule2]` decorators are collected into a single template-module binding.
+4. At runtime the consumer resolves those services (or the game resolves the multibound fragments/alerts/bottom-bar modules) and uses the UI builder extensions + `UiCssClasses`/`UiEnums` to construct visuals.
+
+So the consumer's only required call is "subclass one `AttributeConfigurator` per context and register it" — everything else is discovered from attributes.
+
+## Dependencies & patterns
+- **Bindito.Core** — `Configurator`, `Scope`, `IProvider<T>`, `MultiBind`, `BindExported`. The whole DI surface is Bindito.
+- **Timberborn** — `[Context]` attribute and mod-loading lifecycle; `EntityPanelModule`, `AlertPanelModule`, `BottomBarModule`, `IEntityPanelFragment`, `TemplateModule`/decorators; UIElements (`VisualElement`, USS).
+- **Unity UIElements / UnityEditor** — global usings pull in `UnityEditor.StyleSheets` and `UnityEditor.UIElements.Debugger` (used by `UnityUiElements/` USS-export tooling). Note these are editor namespaces.
+- **Pattern: attribute-driven registration** — declarative `[Bind]` attributes replace imperative configurator code; context flags give per-game-state activation. `zGlobalUsings.cs` centralizes namespace imports (note aliases `NineSliceFloatField` and `TProgressBar = Timberborn.CoreUI.ProgressBar`).
+
+## Subfolder map
+- **`DIAttributes/`** — the `[Bind]`/`[AddTemplateModule]` attributes and `AttributeBinder` that applies them (the DI heart).
+- **`CommonProviders/`** — reusable Bindito `IProvider<...>` base classes for fragments, alerts, bottom-bar modules, dropdown items.
+- **`CommonUi/`** — concrete UIElements controls (dialog boxes, sliders, dropdown rows, progress bars, toggle groups, entity-panel fragment scaffolding, alert elements).
+- **`Extensions/`** — the bulk of the fluent API: `Configurator` binding helpers (`Configurators.cs`, `ConfiguratorHelpers.cs`) and dozens of UI builder extensions (buttons, texts, sliders, dropdowns, dialogs, images, text fields, progress bars).
+- **`Helpers/`** — utilities: list extensions, serializable float/int wrappers, `TimberUiUtils`, WAV loading, configurator helpers.
+- **`Services/`** — runtime services: dialogs, camera shake, mod audio clips, mod update checks, entity-panel ordering, named icons, system file dialog, min/max slider init, text textures.
+- **`Tools/`** — `SelectEntityTool` (a Timberborn `Tool`).
+- **`UnityUiElements/`** — editor-side USS/UXML export tooling (`StyleSheetToUss`, `UxmlExporter`).
+- **`Localizations/`** — `enUS.csv` localization keys shipped by the library.
+
+## Notes
+- **`BindAttributeContext.All` = `MainMenu|Game|MapEditor` (not `Bootstrapper`).** A `[Bind(Contexts = All)]` type is not registered in the bootstrapper scope.
+- The four `MConfigs` rely on Timberborn's `[Context(string)]` attribute matching the loader's expected context names; the `nameof(BindAttributeContext.X)` strings must equal what Timberborn expects, so TimberUi's enum names are coupled to Timberborn's context naming.
+- `GetAssembly()` defaults to the configurator subclass's assembly — a mod that puts its configurator in a different assembly than its `[Bind]` types must override `GetAssembly()`, or those types will not be scanned.
+- `EntityPanelFragmentPosition.RightHeader` is `[Obsolete]`; prefer the current position values (see `CommonProviders`).

--- a/TimberUi/TimberUi/Services/CameraShake/README.md
+++ b/TimberUi/TimberUi/Services/CameraShake/README.md
@@ -1,0 +1,20 @@
+# CameraShake
+
+## Purpose
+A small two-class subsystem that lets mods shake the game camera (e.g. for impacts, explosions, feedback) and lets the player turn the effect off. `CameraShakeService` drives the per-frame jitter of the camera target position and angles; `CameraShakeSettingService` owns a persisted boolean preference and injects a toggle into the game's settings UI.
+
+## Key types
+- **`CameraShakeService`** (`CameraShakeService.cs`) — `IUpdatableSingleton`. Public API: `MoveTo(SelectableObject)` (centers the camera on a target via `CameraTargeter`, returns `this` for chaining) and `Shake(float duration, float strength)` (amplitude = `0.05f * strength`). Each frame, `UpdateSingleton` decrements `duration` by `Time.unscaledDeltaTime`, applies a random `insideUnitSphere * amplitude` offset to `cameraService.Target` plus random vertical/horizontal angle tilt, and restores the original transform when time runs out (`StopShaking`). Both `MoveTo` and `Shake` early-return when shake is disabled.
+- **`CameraShakeSettingService`** (`CameraShakeSettingService.cs`) — `ILoadableSingleton`. Persists `IsDisabled` under settings key `TimberUi.CameraShakeDisabled`. Exposes `IsDisabled` (get) and `SetDisabledCamera(bool)`, plus an `OnCameraShakeDisabledChanged` event. On `Load` it reads the saved bool and calls `AddSettingOption`, which adds a toggle ("LV.TimberUi.DisableCameraShake") into the settings box and inserts it after the existing "UIScaleFactor" row.
+
+## How it fits together
+`CameraShakeService` depends on `CameraShakeSettingService` and gates all of its behavior on `IsDisabled` — so disabling the setting suppresses both shaking and `MoveTo`. The setting service stands alone otherwise (it wires the player-facing toggle), and the shake service is the runtime consumer. State (`originalPos`/`originalRot`) is captured the first time a shake starts and reused if `Shake` is called again mid-shake.
+
+## Dependencies & patterns
+- `CameraShakeService` ← `CameraService` (reads/writes `Target`, `VerticalAngle`, `HorizontalAngle`), `CameraShakeSettingService`, `CameraTargeter`.
+- `CameraShakeSettingService` ← `ISettings` (`GetSafeBool`/`SetBool`), `ISettingsController`, `ILoc`.
+- Uses `Time.unscaledDeltaTime` so shake runs even while the game is paused/slowed.
+- `StopShaking` is also reachable publicly; it restores the original camera transform and clears the active-shake state.
+
+## Usage notes
+- Calling `Shake` again before the previous shake finishes extends the duration without resetting the baseline origin — the camera will restore to the position captured at the start of the first shake. This is the expected behavior when chaining rapid shakes.

--- a/TimberUi/TimberUi/Services/CameraShake/README.md
+++ b/TimberUi/TimberUi/Services/CameraShake/README.md
@@ -17,4 +17,4 @@ A small two-class subsystem that lets mods shake the game camera (e.g. for impac
 - `StopShaking` is also reachable publicly; it restores the original camera transform and clears the active-shake state.
 
 ## Usage notes
-- Calling `Shake` again before the previous shake finishes extends the duration without resetting the baseline origin — the camera will restore to the position captured at the start of the first shake. This is the expected behavior when chaining rapid shakes.
+- Calling `Shake` again before the previous shake finishes overwrites the remaining duration without resetting the baseline origin — the camera will restore to the position captured at the start of the first shake. This is the expected behavior when chaining rapid shakes.

--- a/TimberUi/TimberUi/Services/Dialogs/README.md
+++ b/TimberUi/TimberUi/Services/Dialogs/README.md
@@ -1,0 +1,20 @@
+# Dialogs
+
+## Purpose
+Holds custom dialog `VisualElement`s that extend the base TimberUi `DialogBoxElement`. Currently a single type: `PromptDialogElement`, a modal text-input dialog (label + text field + OK/Cancel) used by `DialogService.PromptAsync` to ask the user for a string.
+
+## Key types
+- **`PromptDialogElement`** (`PromptDialogElement.cs`) — extends `DialogBoxElement`. Built in its constructor: a close button, a hidden-by-default game `Label` (`lblPrompt`), a `TextField` named `"PromptInput"`, and a row with OK/Cancel menu buttons wired to the inherited `OnUIConfirmed`/`OnUICancelled`. Fluent setters `SetPrompt(string)` (shows/hides the label based on emptiness) and `SetValue(string)` (seeds the text field). `ShowAsync(VisualElementInitializer, PanelStack)` starts the base show, focuses the text field, awaits the confirm result, and returns `txt.value` on confirm or `null` on cancel.
+
+## How it fits together
+`DialogService.PromptAsync` constructs a `PromptDialogElement(t)`, optionally calls `SetTitle`/`SetPrompt`/`SetValue`, then awaits `ShowAsync` — the returned `string?` flows straight back to the caller. The element relies entirely on the base `DialogBoxElement` for the confirm/cancel `Task<bool>` plumbing and panel lifecycle; this class only adds the text-input surface and the string result mapping.
+
+## Dependencies & patterns
+- Inherits the dialog lifecycle/`ShowAsync(...) : Task<bool>` machinery from `DialogBoxElement`; uses its `Content`, `AddCloseButton`, `OnUIConfirmed`, `OnUICancelled`.
+- Builder/fluent extension helpers: `AddGameLabel`, `AddTextField`, `AddRow`, `AddMenuButton`, `SetDisplay`, `SetMarginBottom`.
+- `ILoc t` only used to localize the "Core.OK"/"Core.Cancel" button labels.
+
+## Usage notes
+- `SetTitle` is inherited from `DialogBoxElement` and is called by `DialogService.PromptAsync` — it is not defined in this file.
+- Call `SetPrompt(string)` with a non-empty string to display a prompt label above the text field; the label is hidden by default.
+- The result contract is: confirmed ⇒ current text field value (may be `""`), cancelled ⇒ `null`. An empty-but-confirmed field returns `""` rather than `null`.

--- a/TimberUi/TimberUi/Services/EntityPanelOrder/README.md
+++ b/TimberUi/TimberUi/Services/EntityPanelOrder/README.md
@@ -1,0 +1,21 @@
+# EntityPanelOrder
+
+## Purpose
+Lets mods control the vertical ordering of their fragments within the in-game entity selection panel relative to vanilla fragments. A mod registers an `IEntityFragmentOrder` (binding a `VisualElement` to an integer `Order`); `EntityFragmentOrderService` runs once on load and re-inserts those fragments so negative-ordered ones float to the top and positive-ordered ones sink to the bottom.
+
+## Key types
+- **`IEntityFragmentOrder`** (`IEntityFragmentOrder.cs`) — contract a mod implements per orderable fragment. `int Order { get; }` (negative ⇒ guaranteed above vanilla fragments, positive ⇒ guaranteed below, 0 ⇒ neutral / no repositioning) and `VisualElement Fragment { get; }` (the element to move).
+- **`EntityFragmentOrderService`** (`EntityFragmentOrderService.cs`) — `[BindSingleton(Contexts = NonMenu)]`, `ILoadableSingleton`. Collects all `IEnumerable<IEntityFragmentOrder>`, sorts by `Order`, and on `Load` walks them: negatives are inserted from index 0 downward (chained via `InsertSelfAfter`), positives are appended after the last existing child and chained after each other. Also injects `IEntityPanel` purely as a DI ordering dependency (unread — `CS9113` suppressed) to guarantee the panel is constructed first.
+
+## How it fits together
+This is a registration-driven service: any number of `IEntityFragmentOrder` implementations bound into the container are gathered and applied in one pass. It mutates the live entity panel's `VisualElement` tree (`panel.parent.Insert` / `InsertSelfAfter`), so it must run after the panel and all fragments exist — hence the unused `IEntityPanel` constructor dependency forcing DI order, and the `NonMenu` context (no entity panel in the main menu).
+
+## Dependencies & patterns
+- Multi-injection of `IEnumerable<IEntityFragmentOrder>` (the standard "collect all implementers" pattern).
+- `InsertSelfAfter` extension and Unity `VisualElement.parent.Insert` / `.Children().Last()` for DOM reordering.
+- Deliberate unread-parameter DI-ordering trick (documented inline with `#pragma warning disable CS9113`).
+
+## Usage notes
+- `Order` values: negative integers place a fragment above vanilla content, positive integers place it below, and `0` leaves the fragment in its default position.
+- When multiple fragments share the same `Order` value, their relative ordering follows the sort-stable order they appear in after `OrderBy` — assign distinct values if precise relative ordering between mod fragments matters.
+- All registered `Fragment` elements must already be attached to the panel's `VisualElement` tree when `Load` runs. The ordering pass is applied once at load time.

--- a/TimberUi/TimberUi/Services/ModAudioClip/README.md
+++ b/TimberUi/TimberUi/Services/ModAudioClip/README.md
@@ -1,0 +1,22 @@
+# ModAudioClip
+
+## Purpose
+Loads mod-supplied audio (`.wav`) into Timberborn's audio system and lets mods register/replace/remove named clips at runtime. Two pieces: `ModAudioClipConverter` is a file converter that turns `.wav` files discovered in mod folders into Unity `AudioClip`s during mod asset loading; `AudioClipManagementService` is the runtime facade for adding, replacing, removing, and enumerating clips in the game's `AudioClipService`.
+
+## Key types
+- **`ModAudioClipConverter`** (`ModAudioClipConverter.cs`) — `IModFileConverter<AudioClip>`. `ValidExtensions` = `{ ".wav" }` (FrozenSet). `CanConvert` matches by lowercased extension. `TryConvert` decodes via `WavUtility.ToAudioClip(fullPath)` (wrapping any failure in `InvalidDataException`), records a `ModAudioClip(FullName, AudioClip)`, and returns true. `Reset` destroys all tracked `AudioClip`s (`UnityEngine.Object.Destroy`) and clears the list. Exposes `IReadOnlyList<ModAudioClip> AudioClips`.
+- **`ModAudioClip`** (same file) — `readonly record struct (string FullName, AudioClip AudioClip)`.
+- **`AudioClipManagementService`** (`AudioClipManagementService.cs`) — runtime facade over `AudioClipService`. `AllAudioClips` exposes the game's `_audioClips` dictionary read-only. `AddOrReplace(filePath, name?)` loads via `TimberUiUtils.LoadAudioClipFrom` and registers the clip; the effective registry key is the `name` argument when provided, or the file name (without extension) when `name` is null — this value is passed through to `AudioClip.Create` and then read back as the clip's `name`. `AddOrReplace(name, clip)` writes directly into `_audioClips`. `Remove(name)` removes from it.
+
+## How it fits together
+The converter participates in TimberUi/Timberborn's mod file-conversion pipeline (anything implementing `IModFileConverter<T>` is invoked over mod files); it produces `AudioClip`s and keeps a list for lifecycle cleanup via `Reset`. The management service is the imperative counterpart for code that wants to inject or swap clips by name into the live `AudioClipService` after load. They are independent entry points to the same underlying audio store.
+
+## Dependencies & patterns
+- Converter ← `WavUtility` (decode), `OrderedFile`/`SerializedObject` metadata from the converter framework, `FrozenSet` for extension matching.
+- Management service ← `AudioClipService` (accesses its `_audioClips` field).
+- `ModAudioClip` record-struct as the converter's tracking unit.
+
+## Usage notes
+- Only `.wav` files are supported. Decode failures throw `InvalidDataException` immediately, so problems surface at load time.
+- When calling `AddOrReplace(filePath, name?)`, the `name` parameter becomes the clip's registry key. Pass an explicit `name` to control the key; omit it (or pass `null`) to use the file name without extension.
+- The converter's `Reset` method destroys the `AudioClip` objects it created. Clips that were also registered with the live `AudioClipService` should be removed from it before or after `Reset` is called, as the converter and the management service do not coordinate cleanup automatically.

--- a/TimberUi/TimberUi/Services/ModUpdate/README.md
+++ b/TimberUi/TimberUi/Services/ModUpdate/README.md
@@ -1,0 +1,22 @@
+# ModUpdate
+
+## Purpose
+Shows a one-time main-menu dialog when an enabled mod advertises a new version. A mod implements `IModUpdateNotifier` to declare its id, the version being announced, and a localization key for the changelog/message; `ModUpdateService` collects all such notifiers, filters to enabled mods and versions the player hasn't already dismissed, and presents per-mod update dialogs.
+
+## Key types
+- **`IModUpdateNotifier`** (`IModUpdateNotifier.cs`) — mod-implemented contract: `string ModId`, `string Version`, `string MessageLocKey`. No update *detection* logic — the mod author asserts "this version has an announcement"; the service handles dedup + display.
+- **`ModUpdateService`** (`ModUpdateService.cs`) — `[BindSingleton(Contexts = MainMenu)]`, `IPostLoadableSingleton`. On `PostLoad`, `QueueMessages` builds a `Stack<ModNotifierPair>` of notifiers whose `ModId` matches an enabled mod's manifest and whose per-version `PlayerPrefs` key (`TimberUi.ModUpdate.{modId}.{version}`) is not yet set. `ShowNotificationsAsync` pops and shows each via `DialogBoxShower.ShowAsync` with Dismiss/Remind buttons; "Dismiss" (`result == true`) writes the PlayerPrefs key so that version won't show again.
+
+## How it fits together
+Pure registration + main-menu lifecycle. All bound `IModUpdateNotifier`s are gathered; cross-referenced against `ModRepository.EnabledMods` (so notifiers for disabled/absent mods are skipped); deduplicated against `PlayerPrefs`. The dialog text is composed from the mod's manifest `Name`, the notifier `Version`, and the localized `MessageLocKey`, wrapped in `LV.TimberUi.UpdateMessage`.
+
+## Dependencies & patterns
+- `IEnumerable<IModUpdateNotifier>` multi-injection; `ModRepository` for enabled-mod manifests; `ILoc` for text; `DialogBoxShower` for the modal.
+- Per-version persistence via Unity `PlayerPrefs` (int 1 = dismissed). `ModNotifierPair` is a private `readonly record struct`.
+- `Stack` is used so messages display in reverse registration/iteration order (LIFO).
+
+## Usage notes
+- The update dialog shows once per process launch per mod version. Returning to the main menu within the same session will not re-show the dialog.
+- Choosing "Remind" stores nothing — the dialog will reappear on the next launch. Choosing "Dismiss" writes the `PlayerPrefs` key, permanently suppressing that version's announcement.
+- The dedup key is `{ModId}.{Version}`. Bumping `Version` in the notifier causes the announcement to re-appear even if the mod content is otherwise unchanged, which allows authors to issue new announcements for new releases.
+- Only enabled mods are checked: notifiers for mods not present in `ModRepository.EnabledMods` are skipped.

--- a/TimberUi/TimberUi/Services/README.md
+++ b/TimberUi/TimberUi/Services/README.md
@@ -1,0 +1,33 @@
+# Services
+
+## Purpose
+The `Services` namespace is the functional core of TimberUi: a collection of DI-bound singletons and helpers that mod authors consume to do common UI work (show dialogs, prompt for text/strings, look up game icons, style sliders, shake the camera, reorder entity-panel fragments, notify about mod updates, load mod audio, render text to textures, open native file dialogs). This README documents only the three files that live directly in the `Services` root; the sub-namespaces each have their own README and are indexed at the bottom.
+
+The root files are small leaf utilities: a high-level async `DialogService` facade, a `MinMaxSliderInitializer` that restyles Unity's two-handle slider, and a `NamedIconProvider` that caches and resolves sprites by friendly name.
+
+## Key types
+- **`DialogService`** (`DialogService.cs`) — `[BindSingleton(Contexts = All)]` partial class. Async facade over `DialogBoxShower`. Provides `Alert`/`AlertAsync` (single confirm), `ConfirmAsync` (ok/cancel returning `bool`, with optional raw or localized button text), and `PromptAsync` (text input returning `string?` — null on cancel). Internally builds a `DialogBoxShower.Builder` and bridges callbacks to `TaskCompletionSource`. `PromptAsync` delegates to `PromptDialogElement` (see Dialogs subfolder).
+- **`MinMaxSliderInitializer`** (`MinMaxSliderInitializer.cs`) — `[MultiBind(typeof(IVisualElementInitializer), Contexts = All)]`, also `ILoadableSingleton`. On load it loads three slider textures from assets; for any `MinMaxSlider` carrying the `UiCssClasses.TimberUiMinMaxSlider` class it restyles the two thumbs (size 25, top margin -10, hover swap) and the tracker bar. Hook into TimberUi's `IVisualElementInitializer` pipeline so styling applies automatically when such a slider is initialized.
+- **`NamedIconProvider`** (`NamedIconProvider.cs`) — `[BindSingleton(Contexts = All)]`. Two-level sprite cache (`spritesByName` + `spritesByPath`) over `IAssetLoader`. Exposes named convenience properties (Food, Logs, Materials, Science, Water from `sprites/topbar/...`; QuestionMark, Clock, Arrow, ScienceAlt from `ui/images/game/...`) plus generic `GetOrLoad(name, path)`, `GetOrLoadTopbar`, `GetOrLoadGameIcon`, and an indexer `this[name]` that reads `spritesByName` (lookup only — the sprite must have been loaded previously via a `GetOrLoad*` call).
+
+## How it fits together
+`DialogService` is the consumer-facing entry for dialogs and sits on top of Timberborn's `DialogBoxShower` plus TimberUi's own `PromptDialogElement`. `MinMaxSliderInitializer` participates in TimberUi's visual-element initialization fan-out (it is multi-bound alongside other `IVisualElementInitializer` implementations). `NamedIconProvider` is a shared sprite registry other UI code can pull from rather than re-loading sprites ad hoc.
+
+## Dependencies & patterns
+- Primary-constructor DI throughout; all three are context-bound singletons (`BindSingleton` / `MultiBind`).
+- `DialogService` uses the `TaskCompletionSource` callback-to-async bridge pattern. `ILoc t` is used for button-text localization.
+- `NamedIconProvider` and `MinMaxSliderInitializer` both depend on `IAssetLoader`. The provider uses lazy get-or-load caching.
+
+## Usage notes
+- When passing both raw and localized button text to `ConfirmAsync`, the localized value takes precedence — the raw value is not used for that button.
+- The named convenience properties on `NamedIconProvider` (e.g. `Food`, `Logs`, `Water`) are the recommended way to retrieve common sprites; they guarantee the sprite is loaded before being returned. The indexer `this[name]` is a direct cache lookup and requires that the sprite was previously loaded via a `GetOrLoad*` call.
+- `MinMaxSliderInitializer` only applies to `MinMaxSlider` elements that also carry the `UiCssClasses.TimberUiMinMaxSlider` CSS class — both conditions must be met.
+
+## Sibling subfolder index
+- **CameraShake/** — `CameraShakeService` (screen-shake driver, `IUpdatableSingleton`) + `CameraShakeSettingService` (persisted enable/disable toggle in settings).
+- **Dialogs/** — `PromptDialogElement`, the text-input dialog used by `DialogService.PromptAsync`.
+- **EntityPanelOrder/** — `EntityFragmentOrderService` + `IEntityFragmentOrder`; reorders entity-panel fragments by an integer Order.
+- **ModAudioClip/** — `AudioClipManagementService` (add/replace/remove clips in the game's `AudioClipService`) + `ModAudioClipConverter` (`.wav` → `AudioClip` file converter).
+- **ModUpdate/** — `IModUpdateNotifier` + `ModUpdateService`; shows main-menu dialogs when an enabled mod advertises an update.
+- **SystemFileDialog/** — `ISystemFileDialogService` with platform implementations (Windows/macOS/Linux) for native open/save file dialogs.
+- **TextTexture/** — text-to-texture rendering subsystem (glyph layout/cache, font service, renderer, models) for drawing text onto Unity textures.

--- a/TimberUi/TimberUi/Services/SystemFileDialog/README.md
+++ b/TimberUi/TimberUi/Services/SystemFileDialog/README.md
@@ -21,7 +21,7 @@ The Windows implementation uses P/Invoke against `comdlg32.dll`; Linux shells ou
   - Windows: `ParseFilter` produces `"{input}\0*ext;*ext...\0\0"` — the raw input as the description and a `*`-prefixed pattern list as the pattern, both null-terminated (Win32 OPENFILENAME format). `null` → `DefaultFilter` = `"All Files\0*.*\0\0"`.
   - Linux/zenity: `--file-filter="Supported files | *.ext *.ext2"`.
   - Linux/kdialog: `"*.ext *.ext2|Supported files"`.
-  - macOS: an AppleScript list `{"ext","ext2"}` passed as the `of type` clause.
+  - macOS (open only): an AppleScript list `{"ext","ext2"}` passed as the `choose file of type ...` clause; the save dialog currently ignores the filter.
 - **Invocation per platform**:
   - **Windows**: populates an `OpenFileName` managed class (marshaled as the OPENFILENAME struct), pre-allocates an `lpstrFile` buffer, sets `nFilterIndex = 1`, and flags. Open uses `OFN_NOCHANGEDIR | OFN_EXPLORER`; Save uses `OFN_OVERWRITEPROMPT | OFN_EXPLORER`. Returns `lpstrFile` on success, `null` on cancel.
   - **Linux**: `RunProcess` starts the tool with `RedirectStandardOutput`, `UseShellExecute = false`, `CreateNoWindow = true`, reads a single line of stdout, waits for exit, and returns the line only if exit code == 0 (zenity returns 1 on cancel).

--- a/TimberUi/TimberUi/Services/SystemFileDialog/README.md
+++ b/TimberUi/TimberUi/Services/SystemFileDialog/README.md
@@ -1,0 +1,35 @@
+# SystemFileDialog
+
+## Purpose
+
+A thin cross-platform abstraction over the native OS "open file" and "save file" dialogs, so mod code can prompt the user for a path without bundling a UI. The interface exposes two methods (`ShowOpenFileDialog`, `ShowSaveFileDialog`), each accepting an optional filter string and returning the chosen path or `null` on cancel. There are three concrete implementations — Windows, Linux, and macOS — selected automatically at runtime based on the current OS.
+
+The Windows implementation uses P/Invoke against `comdlg32.dll`; Linux shells out to `zenity` or `kdialog`; macOS shells out to `osascript` (AppleScript).
+
+## Key types
+
+- **`ISystemFileDialogService`**: the contract. Two nullable-returning methods plus a **static** `TryBinding(Configurator)` that selects the correct implementation by runtime OS and binds it as a singleton. Logs an error for unsupported platforms.
+- **`WindowsSystemFileDialogService`** (`namespace TimberUi.Services.SystemFileDialog`): delegates to the static `WindowsFileDialogs`. `ParseFilter` converts a `;`-delimited extension string into the Win32 double-null-terminated filter format.
+- **`WindowsFileDialogs`** (static helper, same file): the actual P/Invoke layer. Declares `GetOpenFileName`/`GetSaveFileName` from `comdlg32.dll`, the `OpenFileName` (OPENFILENAME) struct, and the `ShowOpen/SaveFileDialog` methods that populate the struct and invoke the native function.
+- **`LinuxSystemFileDialogService`**: tries `zenity` first, falls back to `kdialog`, each detected by `File.Exists` on the tool's path. Builds tool-specific filter arguments and shells out via `Process.Start`, reading one line of stdout.
+- **`MacOSSystemFileDialogService`**: builds an AppleScript snippet (`choose file` / `choose file name`) and runs it through `osascript -e`, returning the POSIX path of the selection.
+
+## How it fits together
+
+- **Selection**: `ISystemFileDialogService.TryBinding` is the single entry point for wiring. It checks `RuntimeInformation.IsOSPlatform(...)` for Windows → Linux → OSX and calls `configurator.TryBind<ISystemFileDialogService>()?.To<...>().AsSingleton()`. `TryBind` returns `null` if already bound, so a consumer can pre-bind their own implementation without being overridden. A consumer's `Configurator` calls `ISystemFileDialogService.TryBinding(this)` during setup.
+- **Filter convention**: callers pass a `;`-delimited list such as `".json;.txt"`. Each platform reshapes it:
+  - Windows: `ParseFilter` produces `"{input}\0*ext;*ext...\0\0"` — the raw input as the description and a `*`-prefixed pattern list as the pattern, both null-terminated (Win32 OPENFILENAME format). `null` → `DefaultFilter` = `"All Files\0*.*\0\0"`.
+  - Linux/zenity: `--file-filter="Supported files | *.ext *.ext2"`.
+  - Linux/kdialog: `"*.ext *.ext2|Supported files"`.
+  - macOS: an AppleScript list `{"ext","ext2"}` passed as the `of type` clause.
+- **Invocation per platform**:
+  - **Windows**: populates an `OpenFileName` managed class (marshaled as the OPENFILENAME struct), pre-allocates an `lpstrFile` buffer, sets `nFilterIndex = 1`, and flags. Open uses `OFN_NOCHANGEDIR | OFN_EXPLORER`; Save uses `OFN_OVERWRITEPROMPT | OFN_EXPLORER`. Returns `lpstrFile` on success, `null` on cancel.
+  - **Linux**: `RunProcess` starts the tool with `RedirectStandardOutput`, `UseShellExecute = false`, `CreateNoWindow = true`, reads a single line of stdout, waits for exit, and returns the line only if exit code == 0 (zenity returns 1 on cancel).
+  - **macOS**: builds a multi-line AppleScript wrapped in try/error, runs `osascript -e '<script>'`, reads all stdout, trims, and returns on exit 0 with non-empty output.
+
+## Dependencies & patterns
+
+- **`System.Runtime.InteropServices`**: `RuntimeInformation`/`OSPlatform` for platform selection; `DllImport`, `StructLayout`, `Marshal`, `CharSet.Auto` for the Windows P/Invoke.
+- **`System.Diagnostics.Process`**: Linux and macOS shell-out.
+- **DI**: the Bartholomew/IoC `Configurator` with `TryBind(...).To(...).AsSingleton()`.
+- **Try/fallback pattern** on Linux (zenity → kdialog). **AppleScript-as-string** on macOS. **Raw Win32 interop** on Windows.

--- a/TimberUi/TimberUi/Services/TextTexture/README.md
+++ b/TimberUi/TimberUi/Services/TextTexture/README.md
@@ -1,0 +1,59 @@
+# TextTexture
+
+## Purpose
+
+This subsystem rasterizes arbitrary strings into a Unity `Texture2D` using an OS-installed font, with full control over wrapping, alignment, tab size, and font size. It exists because Timberborn UI (UI Toolkit / IMGUI) cannot trivially render text into a texture for use as a sprite or material map, and modders sometimes need text baked into a texture (e.g. in-world signage, custom widgets). The pipeline pulls glyphs from Unity's dynamic font atlas, re-renders each glyph into its own tightly-cropped `Texture2D`, lays the glyphs out into lines, and stamps them onto a destination texture via `Graphics.CopyTexture`.
+
+It is a multi-stage pipeline: font cache management → glyph extraction/rendering → layout (line breaking + alignment) → stamping. Two singletons (`TextTextureRenderer`, `TextTextureFontService`) own shared state; per-text instances are `TextTexture` objects you allocate and dispose.
+
+## Key types
+
+- **`TextTextureRenderer`** (singleton, `IUnloadableSingleton`, bound in `Bootstrapper` context, `Exported`): the orchestrator. Owns the `caches` dictionary keyed by `FontDefinitionPair`. Creates `TextTexture` instances, extracts/renders missing glyphs from the Unity font atlas, measures text, and ref-counts caches for disposal. Holds the char constants (`NewLine`, `Tab`, `CarriageReturn`, `Space`) and `GlyphTextureFormat = RGBA32`.
+- **`TextTexture`** (`IDisposable`): one rendered text target. Wraps a destination `Texture2D` of fixed `width`×`height`. `Render(content, options)` lays out and stamps; `Clear()` blits a cached blank texture; `MeasureUnbound` measures without wrapping bounds. Caches `Content`/`currOptions` to skip redundant re-renders.
+- **`TextGlyphCache`** (`IDisposable`): per-font (name+size) glyph store. Holds the Unity `Font`, a `Dictionary<char, TextGlyphCacheEntry> glyphs`, `LineHeight`, `SpaceWidth`, and a `cacheUse` ref-count. `GetMissingGlyphs` yields chars not yet rendered. Disposing destroys every glyph texture and the font.
+- **`TextGlyphCacheEntry`** (record struct): one glyph = `char C`, its cropped `Texture2D`, and the Unity `CharacterInfo` (advance, bearings, uv rect).
+- **`GlyphLayout`** (static): pure layout engine. `Layout(...)` produces a `TextGlyphLayout`. Internally builds "raw lines" via one of three wrap strategies, computes vertical metrics from top/bottom bearings, applies horizontal and vertical alignment, and emits absolute top-left glyph positions.
+- **`TextGlyphLayout` / `TextGlyphLayoutLine` / `TextGlyphLayoutGlyph`** (LayoutModels.cs): immutable layout result — array of placed glyphs (char, entry, top-left `Vector2Int` position, advance), array of lines (start index, count, width, Y), and total `Size`.
+- **`TextTextureFontService`** (singleton, `Bootstrapper`, `Exported`): OS font discovery. Enumerates `Font.GetOSInstalledFontNames()`, resolves a preferred monospace and default font from per-OS preference lists, and can populate a `DropdownRow<string>`.
+- **`TextTextureRenderOptions`** (record struct): `TabSize` (default 4), `WrapMode`, horizontal and vertical `Alignment`. `Default` = center/center, space-wrap.
+- **`TextTextureRenderWrapMode`**: `None`, `Space`, `Anywhere`.
+- **`FontDefinitionPair`** (record struct): `(string Name, int Size)` — the cache key.
+
+## How it fits together
+
+End-to-end render pipeline:
+
+1. **Allocation** — `TextTextureRenderer.Create(width, height, fontNames, fontSize)` calls `Font.CreateDynamicFontFromOSFont(fontNames, size)` (Unity picks the first available from the name list). It builds a `FontDefinitionPair` from the **actual resolved** `font.name` plus the requested size, looks up or creates a `TextGlyphCache`, immediately caches the space glyph (so `SpaceWidth` is valid; `LineHeight` comes straight from `font.lineHeight` and is valid as soon as the font loads), increments `cacheUse`, and returns a `TextTexture` bound to that font def. The `TextTexture` constructor allocates its destination `Texture2D` (RGBA32, point filter, clamp).
+
+2. **Glyph extraction** (`GetGlyphMap` → `RenderMissingGlyphs`) — on `Render`, the renderer computes the unique non-whitespace chars in the content (`GetUniqueGlyphs`), finds which are missing from the cache, and renders them. `RenderMissingGlyphs` calls `font.RequestCharactersInTexture(...)` to force Unity to pack the glyphs into the font's dynamic atlas, then grabs `font.material.mainTexture` as the atlas. For each char it reads `CharacterInfo` (advance, min/max X/Y bearings, uv corners).
+
+3. **Per-glyph re-render** (`RenderGlyphTexture`) — rather than referencing the shared atlas (which moves as it grows), each glyph is baked into its own standalone `Texture2D`. A temporary ARGB32 `RenderTexture` sized to the glyph is activated, cleared, and a single textured `GL.QUADS` is drawn mapping the glyph's four uv corners (`uvBottomLeft`/`Right`, `uvTopRight`/`Left`) to the quad corners — this preserves any rotation or mirroring the atlas packer applied. Pixels are `ReadPixels`'d back, then **alpha-extracted**: each output pixel becomes solid white with alpha = max(r,g,b,a) of the source. This produces a white glyph mask that can be tinted later via material color. Zero-size glyphs (e.g. space) get a 1×1 transparent texture via `CreateEmptyGlyphTexture`.
+
+4. **Layout** (`GlyphLayout.Layout`) — `BuildRawLines` dispatches on `WrapMode`:
+   - `None` (`BuildUnwrappedLines`): only `\n` breaks lines.
+   - `Anywhere` (`BuildAnywhereWrappedLines`): breaks mid-content when the next glyph would exceed `width`.
+   - `Space` (`BuildSpaceWrappedLines`): accumulates words (whitespace-delimited), flushes word-by-word; words longer than `width` fall back to character breaking; trims leading/trailing spaces at break points.
+
+   Line height = `RoundToInt(cache.LineHeight)`. Vertical extent uses the max top bearing (`info.maxY`) and max bottom bearing (`-info.minY`) across all glyphs. `Align()` computes start offsets for `Start`/`Center`/`End`. Each glyph gets an absolute **top-left** position: `x = penX + info.minX`, `y = baselineY - info.maxY`. Whitespace chars only advance the pen.
+
+5. **Stamping** (`TextTexture.StampGlyph`) — for each placed glyph, the top-left layout Y is converted to `Graphics.CopyTexture`'s **bottom-left** convention (`dstY = height - pos.y - src.height`). The glyph rect is clipped against the destination bounds (partial glyphs at edges are cropped), then `Graphics.CopyTexture` blits the glyph texture region into the destination. `Render` first `Clear()`s by copying a cached all-zero "clear texture" of the same dimensions.
+
+6. **Measurement** (`TextTextureRenderer.Measure`) — independent of bounds; walks the string accumulating advances and line heights (with optional `scale`), handling `\n`/`\r`/tab/space, to return a `Vector2Int` size. Used by `TextTexture.MeasureUnbound`.
+
+7. **Disposal / ref-counting** — `TextTexture.Dispose` destroys its destination texture and calls `renderer.OnTextTextureDisposed`, which decrements the font cache's `cacheUse`; when it hits zero the whole `TextGlyphCache` (all glyph textures and the font) is disposed and removed. `Unload()` (singleton teardown) disposes the static clear-texture cache and every font cache.
+
+## Dependencies & patterns
+
+- **Unity**: `Font`, `CharacterInfo`, `Texture2D`, `RenderTexture`, `GL`, `Graphics.CopyTexture`, `Material`. Heavy use of immediate-mode GL for glyph baking.
+- **DI**: `[BindSingleton(Contexts = BindAttributeContext.Bootstrapper, Exported = true)]` on the two services — these live at bootstrapper scope and are exported to dependent mods.
+- **Bartholomew/IoC lifecycle**: `TextTextureRenderer : IUnloadableSingleton` → `Unload()` cleans up native resources on mod unload.
+- **Logging**: `TimberUiUtils.LogVerbose`, `Debug.LogWarning`/`LogError`.
+- **Collections**: `FrozenSet`/`ImmutableArray` for the font services; `record struct` value types throughout.
+- **Ref-counting cache** pattern: shared per-font caches keyed by `(name, size)`, reference-counted by the number of live `TextTexture`s, freed at zero. Glyphs within a cache are rendered lazily and never evicted until the whole cache is freed.
+- **Static texture pools**: blank "clear" textures are cached per `(width, height)` across all `TextTexture` instances (static dict on `TextTexture`).
+
+## Notes
+
+- **Cache key uses resolved font name.** `Create` keys the cache on `font.name` (what Unity actually loaded), so two different `fontNames` lists that resolve to the same OS font correctly share a cache.
+- **Glyphs render as white alpha masks.** Each glyph pixel becomes solid white with alpha = max(r,g,b,a) of the source, preserving anti-aliased edge coverage. Tinting is applied downstream via material color. Sub-pixel colored emoji are not supported by this model.
+- **`TextTextureFontService.PopulateDropdown`** depends on `DropdownRow<string>` from the wider TimberUi widget set.

--- a/TimberUi/TimberUi/Tools/README.md
+++ b/TimberUi/TimberUi/Tools/README.md
@@ -1,0 +1,22 @@
+# Tools
+
+## Purpose
+Provides a single reusable Timberborn `ITool` — `SelectEntityTool` — that lets a mod ask the player to click on an entity in the world and returns the selected `EntityComponent` asynchronously. It wraps Timberborn's tool/cursor/input/highlight services so consuming mods don't have to implement entity-picking input handling themselves.
+
+## Key types
+- **`SelectEntityTool`** — the tool. Implements `ITool`, `IConstructionModeEnabler`, and `IInputProcessor`. Registered via `[BindSingleton(Contexts = BindAttributeContext.NonMenu)]` so it's available in-game (not in menus). Core API is `Task<EntityComponent?> SelectAsync(SelectEntityToolOptions)` — it switches the active tool to itself, awaits a click (or cancellation), and resolves the task with the picked entity or `null`.
+- **`SelectEntityToolOptions`** — a `readonly record struct` configuring a selection session: optional `Source` `BaseComponent` (re-selected when the tool exits), `Cursor` name (defaults to `"PickObjectCursor"`), `HighlightColor` (defaults to `TimberUiUtils.SuccessColor`), and a `Filter` predicate `Func<SelectableObject, bool>` to restrict which objects are pickable.
+
+## How it fits together
+`SelectAsync` creates a `TaskCompletionSource<EntityComponent?>`, stores the options, and calls `toolService.SwitchTool(this)`. Timberborn then drives the tool lifecycle: `Enter()` registers this as an input processor and sets the cursor; `ProcessInput()` (called each frame) raycasts via `SelectableObjectRaycaster`, highlights a valid hit with `RollingHighlighter`, and on a left-click-not-over-UI calls `SetResult` (which completes the task and switches back to the default tool). `Exit()` cancels any pending task with `null`, removes the input processor, resets cursor/highlights, and re-selects `options.Source` via `EntitySelectionService`. The async/TCS bridge is the key pattern: callers `await tool.SelectAsync(...)` and get a clean result without subscribing to tool callbacks.
+
+## Dependencies & patterns
+- Injected Timberborn services: `ToolService`, `CursorService`, `InputService`, `RollingHighlighter`, `SelectableObjectRaycaster`, `EntitySelectionService`.
+- Timberborn interfaces/types: `ITool`, `IConstructionModeEnabler`, `IInputProcessor`, `BaseComponent`, `EntityComponent`, `SelectableObject`.
+- Uses `TimberUiUtils.SuccessColor` (from `../Helpers`) as the default highlight color.
+- Pattern: `TaskCompletionSource` to convert an event/poll-driven tool into an awaitable; `record struct` options bag; defaulting via null-coalescing on each use.
+
+## Notes
+- Calling `SelectAsync` while a previous selection is still pending cancels the earlier one before starting the new session — the earlier `await` resolves to `null`. Both user cancellation and supersession by a new call yield `null`.
+- The tool returns the `EntityComponent` of the hit object. If a selectable object has no `EntityComponent`, the result is `null`. The `Filter` predicate runs on `SelectableObject` before the `EntityComponent` lookup, so filtering is based on the selectable, not the entity component directly.
+- `options` is reset in `Exit()`, so changing options mid-session is not supported.

--- a/TimberUi/TimberUi/UnityUiElements/README.md
+++ b/TimberUi/TimberUi/UnityUiElements/README.md
@@ -19,7 +19,7 @@ These are standalone, leaf debugging utilities — nothing else in the folder co
 - `System.Xml`/`System.Xml.Linq` (`XDocument`, `XElement`, `XmlWriter`) for UXML; `StringBuilder` + `CultureInfo.InvariantCulture` for USS.
 
 ## Notes
-- USS color emission rounds float components to bytes with `MidpointRounding.AwayFromZero`; alpha is formatted to 2 decimals only when not exactly `"1"`. Hex output requires `useColorCode = true`.
+- USS color emission rounds float components to bytes with `MidpointRounding.AwayFromZero`. The exporter intends to emit `rgba(...)` when `a != 1` (alpha to 2 decimals), but `StyleSheetToUss.ToUssString(Color)` currently throws for non-1 alpha due to a formatting bug (string alpha passed to a `{3:F2}` format specifier). Hex output requires `useColorCode = true`.
 - `UxmlExporter.Recurse` skips element names beginning with `'_'` (treated as internal/auto-generated) unless `AutoNameElements` is set.
 - `ToUssString(StyleValueHandle)` throws `ArgumentException` on an unhandled `StyleValueType`, so USS export will surface loudly if an unsupported value type is encountered.
 - These utilities assume a well-formed UIElements hierarchy; no error handling is provided for malformed or cyclic trees.

--- a/TimberUi/TimberUi/UnityUiElements/README.md
+++ b/TimberUi/TimberUi/UnityUiElements/README.md
@@ -1,0 +1,25 @@
+# UnityUiElements
+
+## Purpose
+Debugging and export tooling that reconstructs USS (stylesheet) and UXML (layout) text from live runtime UIElements objects. `StyleSheetToUss` serializes a `StyleSheet` back into USS source text; `UxmlExporter` walks a `VisualElement` tree and dumps it as a UXML XML document. These let a developer inspect or extract the actual styles and layout the game UI is built from at runtime — useful for reverse-engineering Timberborn's panels when authoring matching mod UI.
+
+Both files are lightly trimmed copies of Unity's own internal editor source (UnityCsReference), reproduced here so the code can run against the game's UIElements assemblies without the Unity Editor.
+
+## Key types
+- **`StyleSheetToUss`** (`StyleSheetToUss.cs`) — static converter. Overloads of `ToUssString(...)` turn `Color`, individual `StyleValueHandle`s, value arrays, `StyleRule`s, selectors (`StyleComplexSelector`/`StyleSelectorPart[]`), and properties into USS text via `StringBuilder`. `ToUssSelector(StyleComplexSelector)` returns a selector string. Handles USS specifics: rgb/rgba/hex color emission, `cursor` multi-value property special-casing, functions with arg counts, comma separators.
+- **`UssComments`** / **`UssExportOptions`** (`StyleSheetToUss.cs`) — comment storage (per-rule and per-property dictionaries) and export configuration (indent, color-code mode, whether to emit comments/default values).
+- **`UxmlExporter`** (`UxmlExporter.cs`) — static `Dump(VisualElement, templateId, ExportOptions)` builds an `XDocument` by recursively walking the element tree, emitting `name`/`text`/`class` attributes, namespace prefixes (`ui` → `UnityEngine.UIElements`), and `<Using>` aliases for templates. `ExportOptions` (`[Flags]`) controls newline-on-attributes, style fields, auto-naming, and whether to expand `TemplateContainer` contents.
+
+## How it fits together
+These are standalone, leaf debugging utilities — nothing else in the folder consumes them, and they are invoked on demand. `UxmlExporter.Recurse` descends a `VisualElement` hierarchy; `StyleSheetToUss` walks the parallel `StyleSheet` model (selectors → rules → properties → value handles). Together they recover the two halves (layout + style) of a UIElements UI as text. They depend entirely on Unity's UIElements object model being accessible at runtime.
+
+## Dependencies & patterns
+- **Namespaces are Unity's own:** `StyleSheetToUss.cs` declares `namespace UnityEditor.StyleSheets`; `UxmlExporter.cs` declares `namespace UnityEditor.UIElements.Debugger`. These namespaces are inherited from the upstream Unity source files — the code does not reference the Unity Editor assembly and compiles against the game's `UnityEngine.UIElements` runtime types. The editor namespace is cosmetic/historical.
+- UIElements model types: `StyleSheet`, `StyleRule`, `StyleProperty`, `StyleValueHandle`, `StyleComplexSelector`, `StyleSelectorPart`, `StyleSelectorRelationship`, `StyleValueType`, `VisualElement`, `TemplateContainer`, `TextElement`.
+- `System.Xml`/`System.Xml.Linq` (`XDocument`, `XElement`, `XmlWriter`) for UXML; `StringBuilder` + `CultureInfo.InvariantCulture` for USS.
+
+## Notes
+- USS color emission rounds float components to bytes with `MidpointRounding.AwayFromZero`; alpha is formatted to 2 decimals only when not exactly `"1"`. Hex output requires `useColorCode = true`.
+- `UxmlExporter.Recurse` skips element names beginning with `'_'` (treated as internal/auto-generated) unless `AutoNameElements` is set.
+- `ToUssString(StyleValueHandle)` throws `ArgumentException` on an unhandled `StyleValueType`, so USS export will surface loudly if an unsupported value type is encountered.
+- These utilities assume a well-formed UIElements hierarchy; no error handling is provided for malformed or cyclic trees.


### PR DESCRIPTION
Adds a `README.md` to each folder of the **TimberUi** source tree, as orientation for anyone reading or extending the library. This is independent of #27 (the outward-facing `Docs/TimberUi/` consumer guides) — take either or both.

Each README covers the folder's **purpose**, **key types**, **how the pieces fit together**, and **dependencies & patterns**:

- Library overview (root) + `DIAttributes`, `CommonProviders`, `CommonUi`, `Extensions`, `Helpers`, `Tools`, `UnityUiElements`
- `Services` (overview) + `CameraShake`, `Dialogs`, `EntityPanelOrder`, `ModAudioClip`, `ModUpdate`, `SystemFileDialog`, `TextTexture`

Written from a read-through of the source; happy to adjust depth or drop any that aren't useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)