### PR TITLE
CL v11.0.0: fix LifeProgressor crash on Timberborn 1.1

### DIFF
--- a/ConfigurableLifetime/ModDesc.txt
+++ b/ConfigurableLifetime/ModDesc.txt
@@ -9,4 +9,5 @@ By default this mod does not change anything. You need to confgure it: Menu (Mai
 ===
 Mod source code and donation: https://github.com/datvm/TimberbornMods (feel free to use the code for anything).
 
+v11.0.0: Fix MissingFieldException on Timberborn v1.1 (`LifeProgressor._lifeProgressIncreasePerTick` moved to `LifeService.LifeProgressIncreasePerTick`).
 v10.0.0: Should work with Timberborn v1.0.1.

--- a/ConfigurableLifetime/Patches/LifetimePatches.cs
+++ b/ConfigurableLifetime/Patches/LifetimePatches.cs
@@ -15,7 +15,7 @@ public static class LifetimePatches
         }
 
         __instance.LifeProgress +=
-            __instance._lifeProgressIncreasePerTick
+            __instance._lifeService.LifeProgressIncreasePerTick
             * mul.Value
             / __instance._bonusManager.Multiplier(LifeProgressor.LifeExpectancyBonusId);
 

--- a/ConfigurableLifetime/manifest.json
+++ b/ConfigurableLifetime/manifest.json
@@ -1,8 +1,8 @@
 ﻿{
     "Name": "Configurable Lifetime",
-    "Version": "10.0.0",
+    "Version": "11.0.0",
     "Id": "ConfigurableLifetime",
-    "MinimumGameVersion": "1.0.0",
+    "MinimumGameVersion": "1.1.0",
     "Description": "Configure lifetime of beavers and bots",
     "RequiredMods": [
         { "Id": "eMka.ModSettings" },


### PR DESCRIPTION
## Summary
- Fixes `MissingFieldException` for `LifeProgressor._lifeProgressIncreasePerTick` on Timberborn 1.1 by reading `LifeService.LifeProgressIncreasePerTick` via `_lifeService` instead.
- Bumps Configurable Lifetime to `11.0.0` with `MinimumGameVersion` `1.1.0`.

## Test plan
- [x] Load a colony with adult beavers while Beaver Aging Multiplier is not `1`
- [x] Confirm no `MissingFieldException` while ticking `BeaverAdult`
- [x] Confirm aging still scales with the configured multiplier
- [x] Confirm childhood growth and bot deterioration multipliers still work